### PR TITLE
Add stomp protocol implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ docker or kubernetes.  By default, the config is stored in `/etc/xrootd-monitori
 
 Environment variables:
 
+* SHOVELER_MQ
 * SHOVELER_AMQP_TOKEN_LOCATION
 * SHOVELER_AMQP_URL
 * SHOVELER_AMQP_EXCHANGE
@@ -44,12 +45,18 @@ Environment variables:
 * SHOVELER_LISTEN_IP
 * SHOVELER_VERIFY
 * SHOVELER_QUEUE_DIRECTORY
+* SHOVELER_STOMP_USER
+* SHOVELER_STOMP_PASSWORD
+* SHOVELER_STOMP_URL
+* SHOVELER_STOMP_TOPIC
 
 Message Bus Credentials
 -----------------------
 
-The shoveler uses a [JWT](https://jwt.io/) to authorize with the message bus.  The token will be issued by an 
+When running using AMQP as the protocol to connect the shoveler uses a [JWT](https://jwt.io/) to authorize with the message bus.  The token will be issued by an 
 automated process, but for now, long lived tokens are issued to sites. 
+
+On the other hand, if STOMP is the selected protocol user and password will need to be provided when configuring the shoveler.
 
 Running the Shoveler
 --------------------

--- a/amqp.go
+++ b/amqp.go
@@ -143,17 +143,6 @@ type Session struct {
 	isReady         bool
 }
 
-const (
-	// When reconnecting to the server after connection failure
-	reconnectDelay = 5 * time.Second
-
-	// When setting up the channel after a channel exception
-	reInitDelay = 2 * time.Second
-
-	// When resending messages the server didn't confirm
-	resendDelay = 5 * time.Second
-)
-
 var (
 	errNotConnected  = errors.New("not connected to a server")
 	errAlreadyClosed = errors.New("already closed: not connected to the server")

--- a/config.go
+++ b/config.go
@@ -64,7 +64,7 @@ func (c *Config) ReadConfig() {
 		// Get the Token location
 		c.AmqpToken = viper.GetString("amqp.token_location")
 		log.Debugln("AMQP Token location:", c.AmqpToken)
-	} else {
+	} else if c.MQ == "stomp" {
 		viper.SetDefault("stomp.topic", "xrootd.shoveler")
 
 		c.StompUser = viper.GetString("stomp.user")
@@ -80,6 +80,8 @@ func (c *Config) ReadConfig() {
 
 		c.StompTopic = viper.GetString("stomp.topic")
 		log.Debugln("STOMP Topic:", c.StompTopic)
+	} else {
+		log.Panic("MQ option is not one of the allowed ones (amqp, stomp)")
 	}
 	// Get the UDP listening parameters
 	viper.SetDefault("listen.port", 9993)

--- a/const.go
+++ b/const.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"time"
+)
+
+const (
+	// When reconnecting to the server after connection failure
+	reconnectDelay = 5 * time.Second
+
+	// When setting up the channel after a channel exception
+	reInitDelay = 2 * time.Second
+
+	// When resending messages the server didn't confirm
+	resendDelay = 5 * time.Second
+)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/opensciencegrid/xrootd-monitoring-shoveler
 go 1.15
 
 require (
+	github.com/go-stomp/stomp/v3 v3.0.3
 	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/joncrlsn/dque v0.0.0-20211108142734-c2ef48c5192a
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-stomp/stomp/v3 v3.0.3 h1:7YQGJCDMkbA05Rw8dS00LxwU1mhzEHS69gMlPjMZGDk=
+github.com/go-stomp/stomp/v3 v3.0.3/go.mod h1:jTrybHBK20jPdM9iyh65m6GusX6aMf7atfEFZ1nIcgc=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.7.1 h1:DP+LD/t0njgoPBvT5MJLeliUIVQR03hiKR6vezdwHlc=
 github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
@@ -255,8 +257,9 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -793,8 +796,9 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.66.2 h1:XfR1dOYubytKy4Shzc2LHrrGhU0lDCfDGG1yLPmpgsI=
 gopkg.in/ini.v1 v1.66.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 	if config.MQ == "amqp" {
 		// Start the AMQP go func
 		go StartAMQP(&config, cq)
-	} else {
+	} else if config.MQ == "stomp" {
 		// Start the STOMP go func
 		go StartStomp(&config, cq)
 	}

--- a/main.go
+++ b/main.go
@@ -34,8 +34,13 @@ func main() {
 	// Start the message queue
 	cq := NewConfirmationQueue()
 
-	// Start the AMQP go func
-	go StartAMQP(&config, cq)
+	if config.MQ == "amqp" {
+		// Start the AMQP go func
+		go StartAMQP(&config, cq)
+	} else {
+		// Start the STOMP go func
+		go StartStomp(&config, cq)
+	}
 
 	// Start the metrics
 	StartMetrics()

--- a/stomp.go
+++ b/stomp.go
@@ -14,7 +14,7 @@ func StartStomp(config *Config, queue *ConfirmationQueue) {
 	stompUser := config.StompUser
 	stompPassword := config.StompPassword
 	stompUrl := config.StompURL
-	stompTopic := config.StompTopic
+	stompTopic := "/topic/" + config.StompTopic
 
 	stompSession := NewStompConnection(stompUser, stompPassword,
 		*stompUrl, stompTopic)
@@ -87,7 +87,8 @@ sendMessageLoop:
 		err := session.conn.Send(
 			session.topic,
 			"text/plain",
-			msg)
+			msg,
+			stomp.SendOpt.Receipt)
 
 		if err != nil {
 			log.Errorln("Failed to publish message:", err)

--- a/stomp.go
+++ b/stomp.go
@@ -57,9 +57,11 @@ func NewStompConnection(username string, password string,
 // handleReconnect reconnects to the stomp server
 func (session *StompSession) handleReconnect() {
 	// Close the current session
-	err := session.conn.Disconnect()
-	if err != nil {
-		log.Errorln("Error handling the diconnection:", err.Error())
+	if session.conn != nil {
+		err := session.conn.Disconnect()
+		if err != nil {
+			log.Errorln("Error handling the diconnection:", err.Error())
+		}
 	}
 
 reconnectLoop:

--- a/stomp.go
+++ b/stomp.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	stomp "github.com/go-stomp/stomp/v3"
+	"net/url"
+)
+
+func StartStomp(config *Config, queue *ConfirmationQueue) error {
+
+	// TODO: Get the username, password, server, topic from the config
+	stompSession := NewStompConnection()
+
+	// Message loop, constantly be dequeing and sending the message
+	// No fancy stuff needed
+	for {
+		msg, err := queue.Dequeue()
+		if err != nil {
+			return err
+		}
+		stompSession.publish(msg)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type StompSession struct {
+	Username string
+	Password string
+	stompUrl url.URL
+	Topic    string
+	conn     *stomp.Conn
+}
+
+func NewStompConnection() *StompSession {
+	return &StompSession{}
+}
+
+// handleReconnect reconnects to the stomp server
+func (session *StompSession) handleReconnect() {
+	// Close the current session
+
+	// Start a new session
+	conn, err := stomp.Dial("tcp", session.stompUrl.String())
+}
+
+// publish will send the message to the stomp message bus
+// It will also handle any error in sending by calling handleReconnect
+func (session *StompSession) publish(msg []byte) error {
+
+	return nil
+}

--- a/stomp.go
+++ b/stomp.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/url"
+	"strings"
 	"time"
 
 	stomp "github.com/go-stomp/stomp/v3"
@@ -14,7 +15,11 @@ func StartStomp(config *Config, queue *ConfirmationQueue) {
 	stompUser := config.StompUser
 	stompPassword := config.StompPassword
 	stompUrl := config.StompURL
-	stompTopic := "/topic/" + config.StompTopic
+	stompTopic := config.StompTopic
+
+	if !strings.HasPrefix(stompTopic, "/topic/") {
+		stompTopic = "/topic/" + stompTopic
+	}
 
 	stompSession := NewStompConnection(stompUser, stompPassword,
 		*stompUrl, stompTopic)

--- a/stomp.go
+++ b/stomp.go
@@ -1,14 +1,22 @@
 package main
 
 import (
-	stomp "github.com/go-stomp/stomp/v3"
 	"net/url"
+
+	stomp "github.com/go-stomp/stomp/v3"
+	log "github.com/sirupsen/logrus"
 )
 
 func StartStomp(config *Config, queue *ConfirmationQueue) error {
 
 	// TODO: Get the username, password, server, topic from the config
-	stompSession := NewStompConnection()
+	stompUser := config.StompUser
+	stompPassword := config.StompPassword
+	stompUrl := config.StompURL
+	stompTopic := config.StompTopic
+
+	stompSession := NewStompConnection(stompUser, stompPassword,
+		*stompUrl, stompTopic)
 
 	// Message loop, constantly be dequeing and sending the message
 	// No fancy stuff needed
@@ -22,32 +30,51 @@ func StartStomp(config *Config, queue *ConfirmationQueue) error {
 			return err
 		}
 	}
-	return nil
+
 }
 
 type StompSession struct {
-	Username string
-	Password string
+	username string
+	password string
 	stompUrl url.URL
-	Topic    string
+	topic    string
 	conn     *stomp.Conn
 }
 
-func NewStompConnection() *StompSession {
-	return &StompSession{}
+func NewStompConnection(username string, password string,
+	stompUrl url.URL, topic string) *StompSession {
+	session := StompSession{
+		username: username,
+		password: password,
+		stompUrl: stompUrl,
+		topic:    topic,
+	}
+	go session.handleReconnect()
+	return &session
 }
 
 // handleReconnect reconnects to the stomp server
 func (session *StompSession) handleReconnect() {
 	// Close the current session
+	session.conn.Disconnect()
 
 	// Start a new session
-	conn, err := stomp.Dial("tcp", session.stompUrl.String())
+	conn, err := stomp.Dial("tcp", session.stompUrl.String(),
+		stomp.ConnOpt.Login(session.username, session.password))
+	if err != nil {
+		log.Errorln("Failed to connect. Retrying:", err.Error)
+	}
+
+	session.conn = conn
 }
 
 // publish will send the message to the stomp message bus
 // It will also handle any error in sending by calling handleReconnect
 func (session *StompSession) publish(msg []byte) error {
+	err := session.conn.Send(
+		session.topic,
+		"text/plain",
+		msg)
 
-	return nil
+	return err
 }

--- a/stomp.go
+++ b/stomp.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/url"
+	"time"
 
 	stomp "github.com/go-stomp/stomp/v3"
 	log "github.com/sirupsen/logrus"
@@ -78,13 +79,15 @@ sendMessageLoop:
 			msg)
 
 		if err != nil {
+			log.Errorln("Failed to publish message:", err)
 		reconnectLoop:
 			for {
 				reconnectError := session.handleReconnect()
 				if reconnectError == nil {
 					break reconnectLoop
 				} else {
-					log.Errorln("Failed to reconnect:", reconnectError.Error())
+					log.Errorln("Failed to reconnect, retrying:", reconnectError.Error())
+					<-time.After(reconnectDelay)
 				}
 			}
 		} else {

--- a/tests/sendudp.py
+++ b/tests/sendudp.py
@@ -1,6 +1,10 @@
 
+from email import header
 import socket
 import sys
+import struct
+from collections import namedtuple
+import time
 
 def main():
     dest = sys.argv[1]
@@ -11,9 +15,14 @@ def main():
     print("UDP target port:", UDP_PORT)
     print("message:", MESSAGE)
 
+    # Pack the xrootd header
+    Header = namedtuple("header", ["code", "pseq", "plen", "server_start"])
+    header = Header(code=0, pseq=0, plen=len(MESSAGE) + 8, server_start=int(time.time()))
+    buf = struct.pack("!cBHI", header.code.to_bytes(1, byteorder="big"), header.pseq, header.plen, header.server_start) + MESSAGE.encode('utf-8')
+
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
-    for i in range(100000):
-        sock.sendto(bytes(MESSAGE + str(i), "utf-8"), (UDP_IP, UDP_PORT))
+    for i in range(10):
+        sock.sendto(buf, (UDP_IP, UDP_PORT))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes a bit more complete the STOMP protocol file of the implementation.

Things that I think need to be improved:
- Handling publish message error: publish should be retried with a new connection (to hopefully reach a different message broker), in case publication keeps failling message should be discarded? archived?
- Handling reconnection: when an error occurs it should try to reconnect to a different message broker (maybe here I can resolve the list of addresses behing the alias for CERN MB and keep them in memory to loop over them?) and retry until no more addresses are available
- In case the connection can't be stablished, Shoveler should still take messages in and put them in queue, then resume when a connection can be stablished.