### PR TITLE
Adding (v)host configurable for STOMP protocol

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	StompUser     string
 	StompPassword string
 	StompURL      *url.URL
+	StompHost     string
 	StompTopic    string
 }
 
@@ -77,6 +78,9 @@ func (c *Config) ReadConfig() {
 			panic(fmt.Errorf("Fatal error parsing STOMP URL: %s \n", err))
 		}
 		log.Debugln("STOMP URL:", c.StompURL.String())
+
+                c.StompHost = viper.GetString("stomp.host")
+                log.Debugln("STOMP HOST:", c.StompHost)
 
 		c.StompTopic = viper.GetString("stomp.topic")
 		log.Debugln("STOMP Topic:", c.StompTopic)

--- a/stomp.go
+++ b/stomp.go
@@ -15,6 +15,7 @@ func StartStomp(config *Config, queue *ConfirmationQueue) {
 	stompUser := config.StompUser
 	stompPassword := config.StompPassword
 	stompUrl := config.StompURL
+        stompHost := config.StompHost
 	stompTopic := config.StompTopic
 
 	if !strings.HasPrefix(stompTopic, "/topic/") {
@@ -22,7 +23,7 @@ func StartStomp(config *Config, queue *ConfirmationQueue) {
 	}
 
 	stompSession := NewStompConnection(stompUser, stompPassword,
-		*stompUrl, stompTopic)
+		*stompUrl, stompHost, stompTopic)
 
 	// Message loop, constantly be dequeing and sending the message
 	// No fancy stuff needed
@@ -41,16 +42,18 @@ type StompSession struct {
 	username string
 	password string
 	stompUrl url.URL
+        stompHost string
 	topic    string
 	conn     *stomp.Conn
 }
 
 func NewStompConnection(username string, password string,
-	stompUrl url.URL, topic string) *StompSession {
+	stompUrl url.URL, stompHost string, topic string) *StompSession {
 	session := StompSession{
 		username: username,
 		password: password,
 		stompUrl: stompUrl,
+                stompHost: stompHost,
 		topic:    topic,
 	}
 
@@ -73,7 +76,8 @@ reconnectLoop:
 	for {
 		// Start a new session
 		conn, err := stomp.Dial("tcp", session.stompUrl.String(),
-			stomp.ConnOpt.Login(session.username, session.password))
+			stomp.ConnOpt.Login(session.username, session.password),
+                        stomp.ConnOpt.Host(session.stompHost))
 		if err == nil {
 			session.conn = conn
 			break reconnectLoop


### PR DESCRIPTION
I found I had to configure the vhost of the STOMP connection in order to connect to a RabbitMQ server at Edinburgh.

I don't know if it's common/best-practice to have a vhost which is the IP of the host associated with the MQ (this is the default from the go library) but I'm aware of a few use-cases where this has not been the case in a setup, hence I've made it configurable.

I've just added a host parameter to the config so that it's picked up and passed onto RabbitMQ correctly. I think this is probably best as a string, but I can't think of a sensible default to add here other than the rabbitmq one of '/' if it's worth making this an optional config parameter.

Happy to change this to 'vhost' rather than 'host' if having this and a url might cause some confusion.