### PR TITLE
Allow shoveler to map based on XRDHOST env var

### DIFF
--- a/map.go
+++ b/map.go
@@ -13,6 +13,12 @@ var (
 
 // configureMap sets the mapping configuration
 func configureMap() {
+	// When run inside Kubernetes, there may be multiple layers of IP mapping.
+	// Hence, we allow overriding these values based on XRDHOST; XRDHOST is
+	// also the current env var name used to override the advertise hostname =by
+	// the cmsd in the OSG-shipped patches.
+	viper.BindEnv("map.all", "XRDHOST");
+
 	// First, check for the map environment variable
 	mapAll = viper.GetString("map.all")
 


### PR DESCRIPTION
The `XRDHOST` env var is what OSG has settled on as the "override" inside an XCache container indicating what the xrootd instance's advertised hostname should be.

This allows an associated shoveler to utilize the same env var and advertise a specific hostname for received UDP packets.

This can be put in independently of https://github.com/opensciencegrid/xrootd-monitoring-collector/pull/31 but is meant to be paired up with that PR to get the end-to-end working.