### PR TITLE
RFC: Use different default queue path

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -103,6 +103,10 @@ nfpms:
         type: "config|noreplace"
       - src: config/xrootd-monitoring-shoveler.service
         dst: /usr/lib/systemd/system/xrootd-monitoring-shoveler.service
+      - dst: /var/spool/xrootd-monitoring-shoveler/queue
+        type: dir
+        file_info:
+          mode: 0700
     overrides:
       rpm:
         file_name_template: >-

--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ From Docker, you can start the container from the OSG hub with the following com
 The shoveler receives UDP packets and stores them onto a queue before being sent to the message bus.  100 messages 
 are stored in memory.  When the in memory messages reaches over 100, the messages are written to disk under the 
 `SHOVELER_QUEUE_DIRECTORY` (env) or `queue_directory` (yaml) configured directories.  A good default is 
-`/tmp/shoveler-queue`, though it could also go in `/var/...`.  The on-disk queue is persistent across shoveler 
-restarts.
+`/var/spool/xrootd-monitoring-shoveler/queue`. Note that `/var/run` or `/tmp` should not be used, as these directories
+ are not persistent and may be cleaned regularly by tooling such as `systemd-tmpfiles`.
+The on-disk queue is persistent across shoveler restarts.
 
 The queue length can be monitored through the prometheus monitoring metric name: `shoveler_queue_size`.
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -39,8 +39,8 @@ metrics:
 # Directory to store overflow of queue onto disk.
 # The queue keeps 100 messages in memory.  If the shoveler is disconnected from the message bus,
 # it will store messages over the 100 in memory onto disk into this directory.  Once the connection has been re-established
-# the queue will be emptied.  The queue on disk is persistent between restarts.
-queue_directory: /tmp/shoveler-queue
+# the queue will be emptied.  The queue on disk is persistent between restarts, so a persistent directory should be used.
+queue_directory: /var/spool/xrootd-monitoring-shoveler/queue
 
 # Mapping configuration
 # If map.all is set, all messages will be mapped to the configured origin.

--- a/queue.go
+++ b/queue.go
@@ -44,7 +44,7 @@ func ItemBuilder() interface{} {
 // Init initializes the queue
 func (cq *ConfirmationQueue) Init() *ConfirmationQueue {
 	// Set the attributes
-	viper.SetDefault("queue_directory", "/tmp/shoveler-queue")
+	viper.SetDefault("queue_directory", "/var/spool/xrootd-monitoring-shoveler/queue")
 	queueDir := viper.GetString("queue_directory")
 
 	qName := path.Base(queueDir)


### PR DESCRIPTION
`/tmp` is cleaned up regularly by `systemd-tmpfiles`, so persistent queues will be lost if the service is down for prolonged times. Examples of this are e.g. https://github.com/indigo-dc/oidc-agent/issues/519 
On some systems, `/tmp` is stored on a ramdisk, so it will be lost upon reboot. 

For persistent storage, `/var/lib` should be used [according to FHS](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s08.html), and it seems reasonable to use the name of the package as subdirectory there to ensure correct namespacing / prevent collisions. 

Ideally, this directory would be created (with correct SELinux contexts) by the RPM / DEB files — if someone can point me to the location of these, I can also create a PR for these. 