### PR TITLE
gh-actions: add tests for packages built with goreleaser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,123 @@ jobs:
       uses: actions/checkout@v4
     - name: Test
       run: go test ./...
+
+  build-packages:
+    strategy:
+      matrix:
+        go-version: [1.21.x]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v4
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --skip=publish --snapshot
+
+    - name: List build result
+      run: |
+        tree
+
+    - name: Upload amd64 DEB
+      uses: actions/upload-artifact@v3
+      with:
+        name: amd64-deb
+        path: dist/xrootd-monitoring-shoveler*amd64.deb
+
+    - name: Upload x86_64 RPM
+      uses: actions/upload-artifact@v3
+      with:
+        name: x86_64-rpm
+        path: dist/xrootd-monitoring-shoveler*x86_64.rpm
+
+  test-deb-packages:
+    needs: [ build-packages ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os-container: ["debian:oldstable","debian:stable","debian:testing","debian:unstable","rockylinux:8","rockylinux:9"]
+
+    steps:
+    - name: Download amd64 DEB
+      if: ${{ startsWith(matrix.os-container, 'debian:') }}
+      uses: actions/download-artifact@v3
+      with:
+        name: amd64-deb
+
+    - name: Download x86_64 RPM
+      if: ${{ startsWith(matrix.os-container, 'rockylinux:') }}
+      uses: actions/download-artifact@v3
+      with:
+        name: x86_64-rpm
+
+    - name: List packages
+      run: |
+        tree
+
+    - name: Start Debian container
+      if: ${{ startsWith(matrix.os-container, 'debian:') }}
+      run: podman run --privileged --detach --name pkgtest --ipc=host -v ${RUNNER_WORKSPACE}:/root ${{ matrix.os-container }} bash -c "apt-get update && apt-get -y install systemd-sysv && /sbin/init"
+
+    - name: Start RockyLinux container
+      if: ${{ startsWith(matrix.os-container, 'rockylinux:') }}
+      run: |
+        podman run --privileged --detach --name pkgtest --ipc=host -v ${RUNNER_WORKSPACE}:/root ${{ matrix.os-container }} bash -c "dnf -y install systemd && /usr/sbin/init"
+
+    - name: Wait until container is ready
+      run: |
+        while ! $(podman top pkgtest | grep -q journald); do
+          sleep 1
+        done
+
+    - name: Install package on Debian
+      if: ${{ startsWith(matrix.os-container, 'debian:') }}
+      run: |
+        podman exec pkgtest bash -c "dpkg -i /root/xrootd-monitoring-shoveler/xrootd-monitoring-shoveler*amd64.deb"
+
+    - name: Install package on RockyLinux
+      if: ${{ startsWith(matrix.os-container, 'rockylinux:') }}
+      run: |
+        podman exec pkgtest bash -c "dnf -y install /root/xrootd-monitoring-shoveler/xrootd-monitoring-shoveler*x86_64.rpm"
+
+    - name: Test createtoken command
+      run: |
+        podman exec pkgtest createtoken --help
+
+    - name: Create basic config file
+      shell: bash
+      run: |
+        cat > ${RUNNER_WORKSPACE}/basic-config.yaml <<EOF
+        mq: stomp
+
+        listen:
+          port: 9993
+          ip: 0.0.0.0
+
+        verify: true
+
+        metrics:
+          enable: true
+          port: 8000
+
+        queue_directory: /var/spool/xrootd-monitoring-shoveler/queue
+        EOF
+        podman exec pkgtest cp /root/basic-config.yaml /etc/xrootd-monitoring-shoveler/config.yaml
+
+    - name: Test shoveler service
+      run: |
+        podman exec pkgtest systemctl start xrootd-monitoring-shoveler
+        podman exec pkgtest systemctl status xrootd-monitoring-shoveler
+
+    - name: Test shoveler-status
+      run: |
+        podman exec pkgtest shoveler-status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         name: x86_64-rpm
         path: dist/xrootd-monitoring-shoveler*x86_64.rpm
 
-  test-deb-packages:
+  test-packages:
     needs: [ build-packages ]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.21.x]
         os: [ubuntu-latest, macos-latest]
@@ -19,6 +20,7 @@ jobs:
 
   build-packages:
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.21.x]
     runs-on: ubuntu-latest
@@ -59,6 +61,7 @@ jobs:
     needs: [ build-packages ]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         os-container: ["debian:oldstable","debian:stable","debian:testing","debian:unstable","rockylinux:8","rockylinux:9"]
 


### PR DESCRIPTION
This tests building the packages, and also testing the deb and rpm packages on various versions of Debian and RockyLinux.

It covers:
* goreleaser building everything (releasing suppressed)
* installation of deb and rpm packages on various distros
* spinning up distro containers including systemd
* testing the systemd unit with a simple config file
* basic test of the installed createtoken binary
* basic test of the shoveler-status binary

@djw8605 I realized current tests did not cover the systemd service nor packaging yet, so I added this as a first step before I will later on attack adding support for running as non-`root` user. So the tests are essentially the preparation to ensure I don't break anything :wink: . 

Checking the `goreleaser` docs, it seems user creation must be done "classically", i.e. via scripts which are embedded in the packages via `goreleaser`, following distro best practices (sadly, `gorelease` can not do that by itself). 
Hence, having tests covering the packages and the systemd unit in place first seemed important. 
