### PR TITLE
Comment stomp options in default configuration file

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,14 +8,14 @@ amqp:
   topic:
   token_location: /etc/xrootd-monitoring-shoveler/token
 
-# If using stomp protocol
-stomp:
-  user: username
-  password: password
-  url: messagebroker.org:port
-  topic: mytopic
-  cert: path/to/cert/file
-  certkey: path/to/certkey/file
+# If using stomp protocol please configure the following commented lines as needed
+#stomp:
+#  user: username
+#  password: password
+#  url: messagebroker.org:port
+#  topic: mytopic
+#  cert: path/to/cert/file
+#  certkey: path/to/certkey/file
 
 listen:
   port: 9993


### PR DESCRIPTION
Trying to run the docker release as it's and configuring it with environment variables seems to crash as the code still loads some of the configs from the default placeholders.

This way environment variables can still be used if required and otherwise the configuration file needs to be explicitly filled