### PR TITLE
Add EnvironmentFile to service definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ An example configuration file, [config.yaml](config/config.yaml) is in the repo.
 file has a corresponding environment variable, listed below.  The environment variables are useful for deployment in 
 docker or kubernetes.  By default, the config is stored in `/etc/xrootd-monitoring-shoveler`.
 
+When running as a daemon, environment variables can still be used for configuration. The service will be looking for
+them under `/etc/sysconfig/xrootd-monitoring-shoveler`.
+
 Environment variables:
 
 * SHOVELER_MQ

--- a/config/xrootd-monitoring-shoveler.service
+++ b/config/xrootd-monitoring-shoveler.service
@@ -3,6 +3,7 @@ Description=XRootD Monitoring Shoveler for sending UDP Monitoring packets to a m
 
 [Service]
 ExecStart=/usr/bin/xrootd-monitoring-shoveler
+EnvironmentFile=-/etc/sysconfig/xrootd-monitoring-shoveler
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes #22 
Add EnvironmentFile placement to service definition, this will allow to configure any required environment variable in a config file without the need to touch the service one.

This is required as when using certificates for the connection to STOMP some people have reported the need to configure SSL_CERT_DIR.