### PR TITLE
Add forced time reconnection to stomp every hour

### DIFF
--- a/stomp.go
+++ b/stomp.go
@@ -29,7 +29,13 @@ func StartStomp(config *Config, queue *ConfirmationQueue) {
 
 	// Message loop, constantly be dequeing and sending the message
 	// No fancy stuff needed
+  dt := time.Now()
 	for {
+    // Add reconnection every hour to make sure connection to brokers is kept balanced
+    if time.Now().After(dt.Add(1 * time.Hour)) {
+      stompSession.handleReconnect()
+      dt = time.Now()
+    }
 		msg, err := queue.Dequeue()
 		if err != nil {
 			log.Errorln("Failed to read from queue:", err)
@@ -86,7 +92,7 @@ func (session *StompSession) handleReconnect() {
 	if session.conn != nil {
 		err := session.conn.Disconnect()
 		if err != nil {
-			log.Errorln("Error handling the diconnection:", err.Error())
+			log.Errorln("Error handling the disconnection:", err.Error())
 		}
 	}
 


### PR DESCRIPTION
This is a request from the CERN messaging team, they want the shoveler to shift connection to a different node behind the alias to make sure connections across WLCG are kept balanced

The idea is to add a check every one hour and trigger a reconnection, not sure if this is the most goionic way but will be happy to adapt it if needed