### PR TITLE
Run as unprivileged user (and create that user via packages)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -121,6 +121,8 @@ nfpms:
           preinstall: "scripts/rpm-preinstall.sh"
       deb:
         file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Release }}_{{ .Arch }}"
+        scripts:
+          preinstall: "scripts/deb-preinstall.sh"
 
 dockers:
   - image_templates:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -117,6 +117,8 @@ nfpms:
           {{- else }}{{ .Arch }}{{ end }}
         dependencies:
         - systemd
+        scripts:
+          preinstall: "scripts/rpm-preinstall.sh"
       deb:
         file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Release }}_{{ .Arch }}"
 

--- a/config/xrootd-monitoring-shoveler.service
+++ b/config/xrootd-monitoring-shoveler.service
@@ -1,9 +1,13 @@
 [Unit]
 Description=XRootD Monitoring Shoveler for sending UDP Monitoring packets to a message bus
+Requires=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/usr/bin/xrootd-monitoring-shoveler
 EnvironmentFile=-/etc/sysconfig/xrootd-monitoring-shoveler
+User=xrootd-monitoring-shoveler
+Group=xrootd-monitoring-shoveler
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/deb-preinstall.sh
+++ b/scripts/deb-preinstall.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+SERVER_HOME=/var/spool/xrootd-monitoring-shoveler
+SERVER_USER=xrootd-monitoring-shoveler
+SERVER_GROUP=xrootd-monitoring-shoveler
+SERVER_NAME="XRootD monitoring shoveler user"
+
+# create user to avoid running server as root
+# 1. create group if not existing
+if ! getent group "$SERVER_GROUP" >/dev/null; then
+   echo -n "Adding group $SERVER_GROUP.."
+   addgroup --quiet --system $SERVER_GROUP 2>/dev/null ||true
+   echo "..done"
+fi
+# 1. create user if not existing
+if ! getent passwd $SERVER_USER >/dev/null; then
+  echo -n "Adding system user $SERVER_USER.."
+  adduser --quiet \
+          --system \
+          --ingroup $SERVER_GROUP \
+          --no-create-home \
+          --disabled-password \
+          $SERVER_USER 2>/dev/null || true
+  echo "..done"
+fi
+# 3. adjust passwd entry
+usermod -c "$SERVER_NAME" \
+        -d $SERVER_HOME   \
+        -g $SERVER_GROUP  \
+           $SERVER_USER

--- a/scripts/rpm-preinstall.sh
+++ b/scripts/rpm-preinstall.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+getent group xrootd-monitoring-shoveler >/dev/null || groupadd -r xrootd-monitoring-shoveler
+getent passwd xrootd-monitoring-shoveler >/dev/null || \
+       useradd -r -g xrootd-monitoring-shoveler -c "XRootD monitoring shoveler user" \
+       -s /sbin/nologin -d /var/spool/xrootd-monitoring-shoveler xrootd-monitoring-shoveler


### PR DESCRIPTION
This creates a user and group `xrootd-monitoring-shoveler` and runs the service as that user. 
Furthermore, it adds a dependency of the service on `network-online.target` to prevent it from coming up before the network is online. 

While not strictly necessary, it's likely better to merge this after https://github.com/opensciencegrid/xrootd-monitoring-shoveler/pull/34 to ensure it does not break anything, since that PR tests the packaging and execution. 
I tried that in my fork (to ensure I don't break things :wink: ), and it worked well in my tests. 