### PR TITLE
Always read config from config struct

### DIFF
--- a/cmd/shoveler/main.go
+++ b/cmd/shoveler/main.go
@@ -34,9 +34,6 @@ func main() {
 	config := shoveler.Config{}
 	config.ReadConfig()
 
-	// Configure the mapper
-	shoveler.ConfigureMap()
-
 	if DEBUG || config.Debug {
 		logger.SetLevel(logrus.DebugLevel)
 	} else {
@@ -47,7 +44,7 @@ func main() {
 	logrus.Infoln("Starting xrootd-monitoring-shoveler", version, "commit:", commit, "built on:", date, "built by:", builtBy)
 
 	// Start the message queue
-	cq := shoveler.NewConfirmationQueue()
+	cq := shoveler.NewConfirmationQueue(&config)
 
 	if config.MQ == "amqp" {
 		// Start the AMQP go func
@@ -119,7 +116,7 @@ func main() {
 			continue
 		}
 
-		msg := shoveler.PackageUdp(buf[:rlen], remote)
+		msg := shoveler.PackageUdp(buf[:rlen], remote, &config)
 
 		// Send the message to the queue
 		logger.Debugln("Sending msg:", string(msg))

--- a/config.go
+++ b/config.go
@@ -26,6 +26,9 @@ type Config struct {
 	MetricsPort   int
 	StompCert     string
 	StompCertKey  string
+	QueueDir      string
+	IpMapAll      string
+	IpMap         map[string]string
 }
 
 func (c *Config) ReadConfig() {
@@ -112,4 +115,13 @@ func (c *Config) ReadConfig() {
 	viper.SetDefault("metrics.port", 8000)
 	c.MetricsPort = viper.GetInt("metrics.port")
 
+	viper.SetDefault("queue_directory", "/var/spool/xrootd-monitoring-shoveler/queue")
+	c.QueueDir = viper.GetString("queue_directory")
+
+	// Configure the mapper
+	// First, check for the map environment variable
+	c.IpMapAll = viper.GetString("map.all")
+
+	// If the map is not set
+	c.IpMap = viper.GetStringMapString("map")
 }

--- a/map.go
+++ b/map.go
@@ -2,35 +2,18 @@ package shoveler
 
 import (
 	"net"
-
-	"github.com/spf13/viper"
 )
-
-var (
-	mapAll string
-	ipMap  map[string]string
-)
-
-// ConfigureMap sets the mapping configuration
-func ConfigureMap() {
-	// First, check for the map environment variable
-	mapAll = viper.GetString("map.all")
-
-	// If the map is not set
-	ipMap = viper.GetStringMapString("map")
-
-}
 
 // mapIp returns the mapped IP address
-func mapIp(remote *net.UDPAddr) string {
+func mapIp(remote *net.UDPAddr, config *Config) string {
 
-	if mapAll != "" {
-		return mapAll
+	if config.IpMapAll != "" {
+		return config.IpMapAll
 	}
-	if len(ipMap) == 0 {
+	if len(config.IpMap) == 0 {
 		return remote.IP.String()
 	}
-	if ip, ok := ipMap[remote.IP.String()]; ok {
+	if ip, ok := config.IpMap[remote.IP.String()]; ok {
 		return ip
 	}
 	return remote.IP.String()

--- a/map_test.go
+++ b/map_test.go
@@ -19,16 +19,14 @@ func TestSingleIp(t *testing.T) {
 	// If the map is not set
 	config := Config{}
 	config.ReadConfig()
-	ConfigureMap()
-	ipStr := mapIp(&ip)
+	ipStr := mapIp(&ip, &config)
 	assert.Equal(t, "192.168.0.5", ipStr, "Test when map is not set")
 
 	// If the map is set by environment variable
 	err := os.Setenv("SHOVELER_MAP_ALL", "172.168.0.5")
 	assert.NoError(t, err, "Failed to set environment variable SHOVELER_MAP_ALL")
 	config.ReadConfig()
-	ConfigureMap()
-	ipStr = mapIp(&ip)
+	ipStr = mapIp(&ip, &config)
 	assert.Equal(t, "172.168.0.5", ipStr, "Test when map is set by environment variable")
 
 	// If the map is set by config file
@@ -43,13 +41,9 @@ map:
 	err = viper.ReadConfig(bytes.NewBuffer(yamlExample))
 	defer viper.Reset()
 	assert.NoError(t, err, "Failed to read config file")
-	ConfigureMap()
-	defer func() {
-		ipMap = nil
-		mapAll = ""
-	}()
+	config = Config{IpMapAll: viper.GetString("map.all"), IpMap: viper.GetStringMapString("map")}
 	ip = net.UDPAddr{IP: net.ParseIP("192.168.1.5"), Port: 514}
-	assert.Equal(t, "172.168.1.6", mapIp(&ip), "Test when map is set by config file")
+	assert.Equal(t, "172.168.1.6", mapIp(&ip, &config), "Test when map is set by config file")
 	ip = net.UDPAddr{IP: net.ParseIP("172.168.2.7"), Port: 514}
-	assert.Equal(t, "129.93.10.5", mapIp(&ip), "Test when map is set by config file")
+	assert.Equal(t, "129.93.10.5", mapIp(&ip, &config), "Test when map is set by config file")
 }

--- a/packageudp.go
+++ b/packageudp.go
@@ -13,14 +13,14 @@ type Message struct {
 	Data            string `json:"data"`
 }
 
-func PackageUdp(packet []byte, remote *net.UDPAddr) []byte {
+func PackageUdp(packet []byte, remote *net.UDPAddr, config *Config) []byte {
 	msg := Message{}
 	// Base64 encode the packet
 	str := base64.StdEncoding.EncodeToString(packet)
 	msg.Data = str
 
 	// add the remote
-	msg.Remote = mapIp(remote)
+	msg.Remote = mapIp(remote, config)
 	msg.Remote += ":" + strconv.Itoa(remote.Port)
 
 	msg.ShovelerVersion = ShovelerVersion

--- a/packageudp_test.go
+++ b/packageudp_test.go
@@ -11,10 +11,11 @@ import (
 
 func TestPackageUdp(t *testing.T) {
 	log = logrus.New()
-	
+
 	// No mapping enabled
 	ip := net.UDPAddr{IP: net.ParseIP("192.168.0.7"), Port: 12345}
-	packaged := PackageUdp([]byte("asdf"), &ip)
+	config := Config{}
+	packaged := PackageUdp([]byte("asdf"), &ip, &config)
 	assert.NotEmpty(t, packaged)
 	// Parse back the json
 	var pkg Message
@@ -27,8 +28,8 @@ func TestPackageUdp(t *testing.T) {
 func TestPackageUdp_Mapping(t *testing.T) {
 	// Mapping enabled
 	ip := net.UDPAddr{IP: net.ParseIP("192.168.0.8"), Port: 12345}
-	mapAll = "172.0.0.9"
-	packaged := PackageUdp([]byte("asdf"), &ip)
+	config := Config{IpMapAll: "172.0.0.9"}
+	packaged := PackageUdp([]byte("asdf"), &ip, &config)
 	assert.NotEmpty(t, packaged)
 	// Parse back the json
 	var pkg Message
@@ -36,19 +37,16 @@ func TestPackageUdp_Mapping(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "172.0.0.9:12345", pkg.Remote, "Remote IP should be the same")
 	assert.Equal(t, "YXNkZg==", pkg.Data, "Data should be base64 encoded")
-	mapAll = ""
 }
 
 func TestPackageUdp_MappingMultiple(t *testing.T) {
 	// Mapping enabled
 	ip := net.UDPAddr{IP: net.ParseIP("192.168.0.8"), Port: 12345}
-	ipMap = make(map[string]string)
-	defer func() {
-		ipMap = nil
-	}()
-	ipMap["192.168.0.8"] = "172.0.0.10"
-	ipMap["192.168.0.9"] = "172.0.0.11"
-	packaged := PackageUdp([]byte("asdf"), &ip)
+	config := Config{}
+	config.IpMap = make(map[string]string)
+	config.IpMap["192.168.0.8"] = "172.0.0.10"
+	config.IpMap["192.168.0.9"] = "172.0.0.11"
+	packaged := PackageUdp([]byte("asdf"), &ip, &config)
 	assert.NotEmpty(t, packaged)
 	// Parse back the json
 	var pkg Message

--- a/queue.go
+++ b/queue.go
@@ -9,8 +9,6 @@ import (
 	"path"
 	"sync"
 	"time"
-
-	"github.com/spf13/viper"
 )
 
 type MessageStruct struct {
@@ -32,7 +30,9 @@ var (
 )
 
 // NewConfirmationQueue returns an initialized list.
-func NewConfirmationQueue() *ConfirmationQueue { return new(ConfirmationQueue).Init() }
+func NewConfirmationQueue(config *Config) *ConfirmationQueue {
+	return new(ConfirmationQueue).Init(config)
+}
 
 // ItemBuilder creates a new item and returns a pointer to it.
 // This is used when we load a segment of the queue from disk.
@@ -41,13 +41,9 @@ func ItemBuilder() interface{} {
 }
 
 // Init initializes the queue
-func (cq *ConfirmationQueue) Init() *ConfirmationQueue {
-	// Set the attributes
-	viper.SetDefault("queue_directory", "/var/spool/xrootd-monitoring-shoveler/queue")
-	queueDir := viper.GetString("queue_directory")
-
-	qName := path.Base(queueDir)
-	qDir := path.Dir(queueDir)
+func (cq *ConfirmationQueue) Init(config *Config) *ConfirmationQueue {
+	qName := path.Base(config.QueueDir)
+	qDir := path.Dir(config.QueueDir)
 	segmentSize := 10000
 	var err error
 	cq.diskQueue, err = dque.NewOrOpen(qName, qDir, segmentSize, ItemBuilder)

--- a/queue_test.go
+++ b/queue_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,8 +14,8 @@ import (
 func TestQueueInsert(t *testing.T) {
 	log = logrus.New()
 	queuePath := path.Join(t.TempDir(), "shoveler-queue")
-	viper.Set("queue_directory", queuePath)
-	queue := NewConfirmationQueue()
+	config := Config{QueueDir: queuePath}
+	queue := NewConfirmationQueue(&config)
 	defer func(queue *ConfirmationQueue) {
 		err := queue.Close()
 		if err != nil {
@@ -38,8 +37,8 @@ func TestQueueInsert(t *testing.T) {
 // TestQueueEmptyDequeue Make sure the queue stalls on a third dequeue
 func TestQueueEmptyDequeue(t *testing.T) {
 	queuePath := path.Join(t.TempDir(), "shoveler-queue")
-	viper.Set("queue_directory", queuePath)
-	queue := NewConfirmationQueue()
+	config := Config{QueueDir: queuePath}
+	queue := NewConfirmationQueue(&config)
 	queue.Enqueue([]byte("test1"))
 	defer func(queue *ConfirmationQueue) {
 		err := queue.Close()
@@ -75,8 +74,8 @@ func TestQueueEmptyDequeue(t *testing.T) {
 func TestQueueLotsEntries(t *testing.T) {
 
 	queuePath := path.Join(t.TempDir(), "shoveler-queue")
-	viper.Set("queue_directory", queuePath)
-	queue := NewConfirmationQueue()
+	config := Config{QueueDir: queuePath}
+	queue := NewConfirmationQueue(&config)
 	defer func(queue *ConfirmationQueue) {
 		err := queue.Close()
 		if err != nil {


### PR DESCRIPTION
Currently, all but `queue.go` and `map.go` read viper parameters through `Config` struct which was initialized by `Config.ReadConfig()`. In `queue.go`, it reads `queue_directory` directly via viper. In `map.go`, it reads `map` and `map.all` and store in a local variable.

This makes integration of shoveler into other system (like Pelican) difficult as it didn't consistently read the configuration.

To fix, now all the sub-functions are reading a single Config struct which is still initialized in `Config.ReadConfig()`