### PR TITLE
Fix verify header report false on summary packet

### DIFF
--- a/log.go
+++ b/log.go
@@ -4,6 +4,11 @@ import "github.com/sirupsen/logrus"
 
 var log logrus.FieldLogger
 
+func init() {
+	// Give a default logger at the start to avoid null pointer error
+	log = logrus.New()
+}
+
 func SetLogger(logger logrus.FieldLogger) {
 	log = logger
 }

--- a/map_test.go
+++ b/map_test.go
@@ -6,14 +6,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSingleIp(t *testing.T) {
-	log = logrus.New()
 	ip := net.UDPAddr{IP: net.ParseIP("192.168.0.5"), Port: 514}
 
 	// If the map is not set

--- a/packageudp_test.go
+++ b/packageudp_test.go
@@ -5,13 +5,10 @@ import (
 	"net"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPackageUdp(t *testing.T) {
-	log = logrus.New()
-
 	// No mapping enabled
 	ip := net.UDPAddr{IP: net.ParseIP("192.168.0.7"), Port: 12345}
 	config := Config{}

--- a/queue_test.go
+++ b/queue_test.go
@@ -6,13 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
 // TestQueueInsert tests the good validation
 func TestQueueInsert(t *testing.T) {
-	log = logrus.New()
 	queuePath := path.Join(t.TempDir(), "shoveler-queue")
 	config := Config{QueueDir: queuePath}
 	queue := NewConfirmationQueue(&config)

--- a/verify_test.go
+++ b/verify_test.go
@@ -28,6 +28,16 @@ func TestGoodVerify(t *testing.T) {
 
 }
 
+func TestVerifySummaryPacket(t *testing.T) {
+	summaryPacket := `<statistics  
+     tod="int64" ver="chars" src=”chars” tos=”int64”
+     pgm=”chars” ins=”chars” pid=”int” site=”chars”>
+	</statistics>
+	`
+
+	assert.True(t, VerifyPacket([]byte(summaryPacket)), "Failed to verify packet")
+}
+
 // TestBadVerify tests the validation if the packets are not good (random bits)
 func TestBadVerify(t *testing.T) {
 	badHeader := Header{}


### PR DESCRIPTION
For XRootD summary packet, it's in XML format without a byte header. The current verify header function doesn't take into account for such format and will report false on such packet. This PR fixes this issue.

This PR also fixes the null pointer error when running each individual test cases due to nil `log` global variable. This PR add a default `log` value.