### PR TITLE
goreleaser: enforce owner/group on user home and queue director

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,11 @@ jobs:
       run: |
         podman exec pkgtest bash -c "dnf -y install /root/xrootd-monitoring-shoveler/xrootd-monitoring-shoveler*x86_64.rpm"
 
+    - name: Check user/group, permissions on queue directory
+      run: |
+        podman exec pkgtest bash -c "getent passwd xrootd-monitoring-shoveler"
+        podman exec pkgtest bash -c "ls -la /var/spool/"
+
     - name: Test createtoken command
       run: |
         podman exec pkgtest createtoken --help

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,8 +133,8 @@ jobs:
 
     - name: Test shoveler service
       run: |
-        podman exec pkgtest systemctl start xrootd-monitoring-shoveler
-        podman exec pkgtest systemctl status xrootd-monitoring-shoveler
+        podman exec pkgtest systemctl --full --lines=100 start xrootd-monitoring-shoveler
+        podman exec pkgtest systemctl --full --lines=100 status xrootd-monitoring-shoveler
 
     - name: Test shoveler-status
       run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -103,10 +103,18 @@ nfpms:
         type: "config|noreplace"
       - src: config/xrootd-monitoring-shoveler.service
         dst: /usr/lib/systemd/system/xrootd-monitoring-shoveler.service
+      - dst: /var/spool/xrootd-monitoring-shoveler
+        type: dir
+        file_info:
+          mode: 0700
+          owner: xrootd-monitoring-shoveler
+          group: xrootd-monitoring-shoveler
       - dst: /var/spool/xrootd-monitoring-shoveler/queue
         type: dir
         file_info:
           mode: 0700
+          owner: xrootd-monitoring-shoveler
+          group: xrootd-monitoring-shoveler
     overrides:
       rpm:
         file_name_template: >-


### PR DESCRIPTION
While the user is created via preinst scripts with the given home path in `/var/spool/xrootd-monitoring-shoveler`,
the home directory itself is not created.
Install that with the package with appropriate permissions, and pre-create the queue subdirectory.

fixes #56 

This PR also increases the context of `systemctl` log output in tests, and adds some verbose output. 