### PR TITLE
Fix PackageUdp IPv6 formatting for DNS enrichment

### DIFF
--- a/collector/integration_dns_test.go
+++ b/collector/integration_dns_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"testing"
 	"time"
@@ -279,4 +280,127 @@ func TestEndToEnd_DNSEnrichmentCacheHit(t *testing.T) {
 
 	// Verify DNS was NOT called (cache hit)
 	assert.Equal(t, int64(0), mockResolver.lookupCount.Load(), "DNS resolver should NOT have been called (cache hit)")
+}
+
+// TestEndToEnd_WLCGDNSEnrichment verifies that DNS enrichment correctly populates
+// server_host in the WLCG JSON payload produced by buildEnrichedRecord.
+func TestEndToEnd_WLCGDNSEnrichment(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	mockResolver := &mockDNSResolver{
+		lookupFunc: func(ctx context.Context, addr string) ([]string, error) {
+			switch addr {
+			case "128.104.227.159":
+				return []string{"cmssrv138.hep.wisc.edu."}, nil
+			case "192.0.2.1":
+				return []string{"client.example.com."}, nil
+			default:
+				return nil, &net.DNSError{Err: "no such host", Name: addr}
+			}
+		},
+	}
+
+	config := CorrelatorConfig{
+		TTL:                 5 * time.Minute,
+		MaxEntries:          10000,
+		EnableDNSEnrichment: true,
+		DNSCacheTTL:         1 * time.Hour,
+		DNSTimeout:          2 * time.Second,
+		Logger:              logger,
+	}
+	correlator := NewCorrelatorWithConfig(config)
+	correlator.dnsResolver = mockResolver
+	defer correlator.Stop()
+
+	serverStart := int32(1639505770)
+	remoteAddr := "128.104.227.159:1094"
+
+	// User packet — client IP that resolves to a domain
+	userPacket := &parser.Packet{
+		Header: parser.Header{
+			Code:        parser.PacketTypeUser,
+			ServerStart: serverStart,
+		},
+		RemoteAddr: remoteAddr,
+		PacketType: parser.PacketTypeUser,
+		UserRecord: &parser.UserRecord{
+			DictId: 100,
+			UserInfo: parser.UserInfo{
+				Protocol: "https",
+				Username: "cmsprod",
+				Host:     "192.0.2.1",
+			},
+			AuthInfo: parser.AuthInfo{
+				Org: "cms",
+			},
+		},
+	}
+	_, err := correlator.ProcessPacket(userPacket)
+	assert.NoError(t, err)
+
+	// Open packet for a /store path (WLCG-eligible)
+	openRec := parser.FileOpenRecord{
+		Header: parser.FileHeader{RecType: parser.RecTypeOpen, FileId: 1, UserId: 100},
+		FileSize: 1024,
+		User:     100,
+		Lfn:      []byte("/store/data/Run2026/file.root"),
+	}
+	openPacket := &parser.Packet{
+		Header:      parser.Header{Code: parser.PacketTypeFStat, ServerStart: serverStart},
+		RemoteAddr:  remoteAddr,
+		FileRecords: []interface{}{openRec},
+	}
+	_, err = correlator.ProcessPacket(openPacket)
+	assert.NoError(t, err)
+
+	// Close packet
+	closeRec := parser.FileCloseRecord{
+		Header: parser.FileHeader{RecType: parser.RecTypeClose, FileId: 1, UserId: 100},
+		Xfr:    parser.StatXFR{Read: 1024},
+	}
+	closePacket := &parser.Packet{
+		Header:      parser.Header{Code: parser.PacketTypeFStat, ServerStart: serverStart},
+		RemoteAddr:  remoteAddr,
+		FileRecords: []interface{}{closeRec},
+	}
+	records, err := correlator.ProcessPacket(closePacket)
+	assert.NoError(t, err)
+	assert.Len(t, records, 1)
+
+	record := records[0]
+
+	// Verify the record is classified as a WLCG packet
+	assert.True(t, IsWLCGPacket(record), "record should be a WLCG packet")
+	assert.True(t, record.NeedsEnrichment(), "record should need DNS enrichment")
+
+	// Route through the enrichment pipeline
+	doneCh := make(chan EnrichedRecord, 1)
+	correlator.EnqueueForEnrichment(record, EnrichmentDestination{
+		Results:      doneCh,
+		WLCGExchange: "wlcg-exchange",
+	})
+
+	var enrichedMsg EnrichedRecord
+	select {
+	case enrichedMsg = <-doneCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for DNS enrichment")
+	}
+
+	// The enriched record must have the resolved server hostname
+	assert.Equal(t, "cmssrv138.hep.wisc.edu", enrichedMsg.Record.ServerHostname,
+		"ServerHostname should be DNS-resolved")
+
+	// The payload must be WLCG JSON with server_host = resolved hostname
+	assert.Equal(t, "wlcg-exchange", enrichedMsg.Exchange, "exchange should be WLCG exchange")
+
+	var wlcgData map[string]interface{}
+	assert.NoError(t, json.Unmarshal(enrichedMsg.Payload, &wlcgData))
+	assert.Equal(t, "cmssrv138.hep.wisc.edu", wlcgData["server_host"],
+		"server_host in WLCG JSON must be the DNS-resolved hostname, not the raw IP")
+	assert.Equal(t, "128.104.227.159", wlcgData["server_ip"],
+		"server_ip should retain the raw IP address")
+	assert.Equal(t, "wisc.edu", wlcgData["server_domain"],
+		"server_domain should be extracted from the resolved hostname")
 }

--- a/packageudp.go
+++ b/packageudp.go
@@ -19,9 +19,9 @@ func PackageUdp(packet []byte, remote *net.UDPAddr, config *Config) []byte {
 	str := base64.StdEncoding.EncodeToString(packet)
 	msg.Data = str
 
-	// add the remote
-	msg.Remote = mapIp(remote, config)
-	msg.Remote += ":" + strconv.Itoa(remote.Port)
+	// Use net.JoinHostPort so IPv6 addresses are wrapped in brackets,
+	// producing a valid "host:port" string that net.SplitHostPort can parse.
+	msg.Remote = net.JoinHostPort(mapIp(remote, config), strconv.Itoa(remote.Port))
 
 	msg.ShovelerVersion = ShovelerVersion
 

--- a/packageudp_test.go
+++ b/packageudp_test.go
@@ -52,3 +52,22 @@ func TestPackageUdp_MappingMultiple(t *testing.T) {
 	assert.Equal(t, "172.0.0.10:12345", pkg.Remote, "Remote IP should be the same")
 	assert.Equal(t, "YXNkZg==", pkg.Data, "Data should be base64 encoded")
 }
+
+func TestPackageUdp_IPv6(t *testing.T) {
+	// Genuine IPv6 address must be wrapped in brackets so that
+	// net.SplitHostPort can parse the remote address on the collector side.
+	ip := net.UDPAddr{IP: net.ParseIP("2001:db8::1"), Port: 12345}
+	config := Config{}
+	packaged := PackageUdp([]byte("asdf"), &ip, &config)
+	assert.NotEmpty(t, packaged)
+	var pkg Message
+	err := json.Unmarshal(packaged, &pkg)
+	assert.NoError(t, err)
+	assert.Equal(t, "[2001:db8::1]:12345", pkg.Remote)
+
+	// Verify that the result can be parsed back by net.SplitHostPort
+	host, port, splitErr := net.SplitHostPort(pkg.Remote)
+	assert.NoError(t, splitErr, "net.SplitHostPort must succeed for the DNS enrichment path")
+	assert.Equal(t, "2001:db8::1", host)
+	assert.Equal(t, "12345", port)
+}


### PR DESCRIPTION
## Summary

- **Fix `PackageUdp` to use `net.JoinHostPort`** instead of manual string concatenation, so IPv6 server addresses are properly bracketed (e.g. `[2001:db8::1]:1094` instead of `2001:db8::1:1094`). Without brackets, `net.SplitHostPort` fails downstream in the collector's DNS enrichment path, silently skipping hostname resolution.
- **Add `TestPackageUdp_IPv6`** unit test verifying IPv6 addresses round-trip correctly through `net.SplitHostPort`.
- **Add `TestEndToEnd_WLCGDNSEnrichment`** integration test verifying that DNS-resolved hostnames flow all the way into the WLCG JSON payload (`server_host`, `server_ip`, `server_domain`).

## Context

This is a follow-up to the previously merged fix for `extractIPFromHost` breaking IPv4-mapped IPv6 addresses. That fix handled the collector side; this fix addresses the shoveler side where the `remote` field in the UDP message was being formatted incorrectly for IPv6 addresses, preventing downstream parsing.

## Test plan

- [x] `TestPackageUdp_IPv6` passes — verifies bracketed IPv6 format
- [x] `TestEndToEnd_WLCGDNSEnrichment` passes — verifies full pipeline from packet through DNS enrichment to WLCG JSON
- [ ] Verify existing tests still pass (`TestPackageUdp`, `TestPackageUdp_Mapping`, `TestPackageUdp_MappingMultiple`)

https://claude.ai/code/session_01MEduZS6CL6oMCFYXudyYZG