### PR TITLE
Fix WLCG gstream routing by adding field-rename transforms for cache and TPC events

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ The collector performs full packet parsing and correlation:
   - The VO is `cms`, OR
   - The file path starts with `/store` or `/user/dteam`
   - WLCG records are sent to a separate exchange (`amqp.exchange_wlcg`) instead of the main exchange
+  - Cache gstream events with `/store` or `/user/dteam` paths are converted and sent to `amqp.exchange_wlcg_cache`
+  - TPC gstream events with WLCG source/destination paths are converted and sent to `amqp.exchange_wlcg_tpc`
 
 Run with: `xrootd-monitoring-collector` (or `xrootd-monitoring-collector -c /path/to/config.yaml`)
 
@@ -213,6 +215,8 @@ See [config-collector.yaml](config/config-collector.yaml) for a complete example
 * `<PREFIX>_AMQP_EXCHANGE_TCP` - TCP events exchange (default: `xrd-tcp-events`)
 * `<PREFIX>_AMQP_EXCHANGE_TPC` - TPC events exchange (default: `xrd-tpc-events`)
 * `<PREFIX>_AMQP_EXCHANGE_WLCG` - WLCG formatted events exchange (default: `xrd-wlcg-events`)
+* `<PREFIX>_AMQP_EXCHANGE_WLCG_CACHE` - WLCG formatted cache events exchange (default: `xrd-wlcg-cache-events`)
+* `<PREFIX>_AMQP_EXCHANGE_WLCG_TPC` - WLCG formatted TPC events exchange (default: `xrd-wlcg-tpc-events`)
 * `<PREFIX>_AMQP_TOKEN_LOCATION` - JWT token file path (default: `/etc/xrootd-monitoring-shoveler/token`)
 * `<PREFIX>_AMQP_PUBLISH_WORKERS` - Number of concurrent publishing workers for collector mode (default: `10`, forced to `1` in shoveler mode)
 

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -162,23 +162,58 @@ func startRecordPublisher(output connectors.OutputConnector, logger *logrus.Logg
 }
 
 // emitGStreamEvent handles outputting a gstream event to the appropriate exchange
-func emitGStreamEvent(eventJSON []byte, streamType byte, config *shoveler.Config, output connectors.OutputConnector, logger *logrus.Logger) {
-	// Determine exchange based on stream type
+// It checks if WLCG conversion is needed and routes to the appropriate exchange
+func emitGStreamEvent(event map[string]interface{}, streamType byte, config *shoveler.Config, output connectors.OutputConnector, logger *logrus.Logger) {
 	var exchange string
+	var needsWLCG bool
+
 	switch streamType {
 	case 'C': // Cache events
-		exchange = config.AmqpExchangeCache
-	case 'T': // TCP events
+		event = collector.TransformCacheEvent(event)
+		if filePath, ok := event["file_path"].(string); ok && collector.CachePathCheckWLCG(filePath) {
+			exchange = config.AmqpExchangeWLCGCache
+			needsWLCG = true
+		} else {
+			exchange = config.AmqpExchangeCache
+		}
+	case 'T': // TCP events - no WLCG conversion
 		exchange = config.AmqpExchangeTCP
 	case 'P': // TPC events
-		exchange = config.AmqpExchangeTPC
+		event = collector.TransformTPCEvent(event)
+		source, _ := event["source"].(string)
+		destination, _ := event["destination"].(string)
+		if collector.TPCPathCheckWLCG(source) || collector.TPCPathCheckWLCG(destination) {
+			exchange = config.AmqpExchangeWLCGTPC
+			needsWLCG = true
+		} else {
+			exchange = config.AmqpExchangeTPC
+		}
 	default:
 		logger.Warnf("Unknown gstream type: %c (0x%02x), using default exchange", streamType, streamType)
 		exchange = config.AmqpExchange
 	}
 
-	if err := output.WriteToExchange(eventJSON, exchange); err != nil {
-		logger.Errorln("Failed to write gstream event:", err)
+	var eventJSON []byte
+	var err error
+	if needsWLCG {
+		wlcgEvent, convErr := collector.ConvertGStreamToWLCG(event, streamType == 'P')
+		if convErr != nil {
+			logger.Errorln("Failed to convert gstream event to WLCG:", convErr)
+			return
+		}
+		eventJSON, err = json.Marshal(wlcgEvent)
+	} else {
+		eventJSON, err = json.Marshal(event)
+	}
+
+	if err != nil {
+		logger.Errorln("Failed to marshal gstream event:", err)
+		return
+	}
+
+	logger.Debugln("Emitting gstream event to", exchange+":", string(eventJSON))
+	if writeErr := output.WriteToExchange(eventJSON, exchange); writeErr != nil {
+		logger.Errorln("Failed to write gstream event:", writeErr)
 	}
 }
 
@@ -264,14 +299,7 @@ func handleParsedPacket(packet *parser.Packet, correlator *collector.Correlator,
 
 		// Emit each gstream event to the appropriate exchange
 		for _, event := range events {
-			eventJSON, err := json.Marshal(event)
-			if err != nil {
-				logger.Errorln("Failed to marshal gstream event:", err)
-				continue
-			}
-
-			logger.Debugln("Emitting gstream event:", string(eventJSON))
-			emitGStreamEvent(eventJSON, streamType, config, output, logger)
+			emitGStreamEvent(event, streamType, config, output, logger)
 		}
 		return
 	}

--- a/collector/wlcg_converter.go
+++ b/collector/wlcg_converter.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"encoding/json"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -205,4 +206,108 @@ func ConvertToWLCG(record *CollectorRecord) (*WLCGRecord, error) {
 // ToJSON converts a WLCG record to JSON
 func (w *WLCGRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(w)
+}
+
+// TPCPathCheckWLCG checks if a TPC source/destination URL should be converted to WLCG format
+// Based on references/wlcg_converter.py::tpcPathCheckWLCG
+func TPCPathCheckWLCG(urlStr string) bool {
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		return false
+	}
+	path := strings.TrimLeft(parsedURL.Path, "/")
+	return strings.HasPrefix(path, "store") || strings.HasPrefix(path, "user/dteam")
+}
+
+// CachePathCheckWLCG checks if a cache file path should be converted to WLCG format
+// Based on DetailedCollector.py::process_gstream
+func CachePathCheckWLCG(path string) bool {
+	cleanPath := strings.TrimSpace(path)
+	return strings.HasPrefix(cleanPath, "/store") || strings.HasPrefix(cleanPath, "/user/dteam")
+}
+
+func renameField(m map[string]interface{}, from, to string) {
+	if v, ok := m[from]; ok {
+		m[to] = v
+		delete(m, from)
+	}
+}
+
+func toFloat64(v interface{}) float64 {
+	switch val := v.(type) {
+	case float64:
+		return val
+	case int64:
+		return float64(val)
+	case int:
+		return float64(val)
+	}
+	return 0
+}
+
+// TransformCacheEvent renames raw XRootD cache gstream fields to human-readable names
+// and computes derived byte-count fields. Does not mutate the input map.
+func TransformCacheEvent(event map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(event)+2)
+	for k, v := range event {
+		out[k] = v
+	}
+
+	renameField(out, "lfn", "file_path")
+	renameField(out, "blk_size", "block_size")
+	renameField(out, "n_blks", "numbers_blocks")
+	renameField(out, "n_blks_done", "numbers_blocks_done")
+	renameField(out, "access_cnt", "access_count")
+	renameField(out, "attach_t", "attach_time")
+	renameField(out, "detach_t", "detach_time")
+	renameField(out, "b_hit", "bytes_hit_cache")
+	renameField(out, "b_miss", "bytes_miss_cache")
+	renameField(out, "b_bypass", "bytes_bypass_cache")
+	renameField(out, "b_todisk", "bytes_to_disk")
+	renameField(out, "b_prefetch", "bytes_by_prefetch")
+	renameField(out, "n_cks_errs", "numbers_checksum_errors")
+
+	todisk := toFloat64(out["bytes_to_disk"])
+	bypass := toFloat64(out["bytes_bypass_cache"])
+	prefetch := toFloat64(out["bytes_by_prefetch"])
+	out["bytes_read_by_remote"] = todisk + bypass
+	out["bytes_explicit_remote_read"] = todisk + bypass - prefetch
+
+	return out
+}
+
+// GStreamMetadata contains metadata added to gstream events in WLCG format
+type GStreamMetadata struct {
+	Producer   string `json:"producer"`
+	Type       string `json:"type"`
+	Timestamp  int64  `json:"timestamp"`
+	TypePrefix string `json:"type_prefix"`
+	Host       string `json:"host"`
+	ID         string `json:"_id"`
+}
+
+// ConvertGStreamToWLCG adds WLCG metadata to a gstream event map
+// Based on references/wlcg_converter.py::ConvertGstream
+func ConvertGStreamToWLCG(event map[string]interface{}, isTPC bool) (map[string]interface{}, error) {
+	eventCopy := make(map[string]interface{})
+	for k, v := range event {
+		eventCopy[k] = v
+	}
+
+	hostname, _ := os.Hostname()
+	eventType := "metric"
+	if isTPC {
+		eventType = "tpc"
+	}
+
+	eventCopy["metadata"] = GStreamMetadata{
+		Producer:   "cms-xrootd-cache",
+		Type:       eventType,
+		Timestamp:  time.Now().UnixNano() / int64(time.Millisecond),
+		TypePrefix: "raw",
+		Host:       hostname,
+		ID:         uuid.New().String(),
+	}
+
+	return eventCopy, nil
 }

--- a/collector/wlcg_converter.go
+++ b/collector/wlcg_converter.go
@@ -276,6 +276,8 @@ func TransformCacheEvent(event map[string]interface{}) map[string]interface{} {
 	return out
 }
 
+// TransformTPCEvent renames raw XRootD TPC gstream fields to human-readable names.
+// Does not mutate the input map.
 func TransformTPCEvent(event map[string]interface{}) map[string]interface{} {
 	out := make(map[string]interface{}, len(event))
 	for k, v := range event {

--- a/collector/wlcg_converter.go
+++ b/collector/wlcg_converter.go
@@ -276,6 +276,38 @@ func TransformCacheEvent(event map[string]interface{}) map[string]interface{} {
 	return out
 }
 
+func TransformTPCEvent(event map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(event))
+	for k, v := range event {
+		out[k] = v
+	}
+
+	renameField(out, "TPC", "tpc_protocol")
+	renameField(out, "Client", "client")
+	renameField(out, "Src", "source")
+	renameField(out, "Dst", "destination")
+	renameField(out, "Size", "size")
+
+	if xeqRaw, ok := out["Xeq"]; ok {
+		if xeqMap, ok := xeqRaw.(map[string]interface{}); ok {
+			xeq := make(map[string]interface{}, len(xeqMap))
+			for k, v := range xeqMap {
+				xeq[k] = v
+			}
+			renameField(xeq, "Beg", "begin_transfer")
+			renameField(xeq, "End", "end_transfer")
+			renameField(xeq, "IPv", "ip_version")
+			renameField(xeq, "RC", "return_code")
+			renameField(xeq, "Strm", "used_streams")
+			renameField(xeq, "Type", "flow_direction")
+			out["xeq"] = xeq
+		}
+		delete(out, "Xeq")
+	}
+
+	return out
+}
+
 // GStreamMetadata contains metadata added to gstream events in WLCG format
 type GStreamMetadata struct {
 	Producer   string `json:"producer"`

--- a/collector/wlcg_converter_test.go
+++ b/collector/wlcg_converter_test.go
@@ -548,6 +548,81 @@ func TestTransformCacheEvent_DerivedFields(t *testing.T) {
 	}
 }
 
+func TestTransformTPCEvent(t *testing.T) {
+	raw := map[string]interface{}{
+		"TPC":    "xroot",
+		"Client": "abh.47358:24@cent7a.slac.stanford.edu",
+		"Xeq": map[string]interface{}{
+			"Beg":  "2022-04-01T04:22:15.765838Z",
+			"End":  "2022-04-01T04:22:15.891503Z",
+			"RC":   float64(0),
+			"Strm": float64(1),
+			"Type": "pull",
+			"IPv":  float64(6),
+		},
+		"Src":  "xroot://cent7b.slac.stanford.edu:1094//store/data/file.root",
+		"Dst":  "xroot://griddev08.slac.stanford.edu:1094//store/data/file.root",
+		"Size": float64(6293536),
+	}
+
+	out := TransformTPCEvent(raw)
+
+	if out["tpc_protocol"] != "xroot" {
+		t.Errorf("tpc_protocol = %v, expected xroot", out["tpc_protocol"])
+	}
+	if out["client"] != "abh.47358:24@cent7a.slac.stanford.edu" {
+		t.Errorf("client = %v, expected abh.47358:24@cent7a.slac.stanford.edu", out["client"])
+	}
+	if out["source"] != "xroot://cent7b.slac.stanford.edu:1094//store/data/file.root" {
+		t.Errorf("source = %v, expected xroot://cent7b.slac.stanford.edu:1094//store/data/file.root", out["source"])
+	}
+	if out["destination"] != "xroot://griddev08.slac.stanford.edu:1094//store/data/file.root" {
+		t.Errorf("destination = %v, expected xroot://griddev08.slac.stanford.edu:1094//store/data/file.root", out["destination"])
+	}
+	if out["size"] != float64(6293536) {
+		t.Errorf("size = %v, expected 6293536", out["size"])
+	}
+
+	for _, old := range []string{"TPC", "Client", "Src", "Dst", "Size", "Xeq"} {
+		if _, ok := out[old]; ok {
+			t.Errorf("old top-level key %q should not be present in result", old)
+		}
+	}
+
+	xeq, ok := out["xeq"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("xeq should be map[string]interface{}, got %T", out["xeq"])
+	}
+	if xeq["begin_transfer"] != "2022-04-01T04:22:15.765838Z" {
+		t.Errorf("begin_transfer = %v, expected 2022-04-01T04:22:15.765838Z", xeq["begin_transfer"])
+	}
+	if xeq["end_transfer"] != "2022-04-01T04:22:15.891503Z" {
+		t.Errorf("end_transfer = %v, expected 2022-04-01T04:22:15.891503Z", xeq["end_transfer"])
+	}
+	if xeq["return_code"] != float64(0) {
+		t.Errorf("return_code = %v, expected 0", xeq["return_code"])
+	}
+	if xeq["used_streams"] != float64(1) {
+		t.Errorf("used_streams = %v, expected 1", xeq["used_streams"])
+	}
+	if xeq["flow_direction"] != "pull" {
+		t.Errorf("flow_direction = %v, expected pull", xeq["flow_direction"])
+	}
+	if xeq["ip_version"] != float64(6) {
+		t.Errorf("ip_version = %v, expected 6", xeq["ip_version"])
+	}
+
+	for _, old := range []string{"Beg", "End", "RC", "Strm", "Type", "IPv"} {
+		if _, ok := xeq[old]; ok {
+			t.Errorf("old xeq key %q should not be present in result", old)
+		}
+	}
+
+	if raw["TPC"] != "xroot" {
+		t.Error("original raw map should not be mutated: TPC key changed")
+	}
+}
+
 func TestConvertGStreamToWLCG_TPC(t *testing.T) {
 	event := map[string]interface{}{
 		"source":      "root://src.cern.ch//store/data/file1.root",

--- a/collector/wlcg_converter_test.go
+++ b/collector/wlcg_converter_test.go
@@ -328,3 +328,244 @@ func TestGenerateUUID(t *testing.T) {
 		t.Errorf("UUID format incorrect: %s", wlcg1.UniqueID)
 	}
 }
+
+func TestCachePathCheckWLCG(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "/store path should be WLCG",
+			path:     "/store/data/file.root",
+			expected: true,
+		},
+		{
+			name:     "/user/dteam path should be WLCG",
+			path:     "/user/dteam/test.dat",
+			expected: true,
+		},
+		{
+			name:     "Non-WLCG path",
+			path:     "/ospool/data/file.txt",
+			expected: false,
+		},
+		{
+			name:     "Empty path",
+			path:     "",
+			expected: false,
+		},
+		{
+			name:     "Path with whitespace",
+			path:     "  /store/data/file.root  ",
+			expected: true,
+		},
+		{
+			name:     "partial store path",
+			path:     "/some/store/data/file.root",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CachePathCheckWLCG(tt.path)
+			if result != tt.expected {
+				t.Errorf("CachePathCheckWLCG(%q) = %v, expected %v", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTPCPathCheckWLCG(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{
+			name:     "store path in URL",
+			url:      "root://xrootd.cern.ch//store/data/file.root",
+			expected: true,
+		},
+		{
+			name:     "user/dteam path in URL",
+			url:      "root://xrootd.cern.ch//user/dteam/test.dat",
+			expected: true,
+		},
+		{
+			name:     "Non-WLCG path",
+			url:      "root://xrootd.cern.ch//ospool/data/file.txt",
+			expected: false,
+		},
+		{
+			name:     "Invalid URL",
+			url:      "://invalid",
+			expected: false,
+		},
+		{
+			name:     "Empty URL",
+			url:      "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := TPCPathCheckWLCG(tt.url)
+			if result != tt.expected {
+				t.Errorf("TPCPathCheckWLCG(%q) = %v, expected %v", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConvertGStreamToWLCG(t *testing.T) {
+	event := map[string]interface{}{
+		"file_path":        "/store/data/file.root",
+		"bytes_hit_cache":  int64(1000000),
+		"bytes_miss_cache": int64(500000),
+		"server_hostname":  "xrootd.cern.ch",
+	}
+
+	wlcgEvent, err := ConvertGStreamToWLCG(event, false)
+	if err != nil {
+		t.Fatalf("ConvertGStreamToWLCG() error = %v", err)
+	}
+
+	if wlcgEvent["file_path"] != "/store/data/file.root" {
+		t.Errorf("file_path = %v, expected /store/data/file.root", wlcgEvent["file_path"])
+	}
+
+	if wlcgEvent["metadata"] == nil {
+		t.Fatal("metadata should not be nil")
+	}
+
+	metadata, ok := wlcgEvent["metadata"].(GStreamMetadata)
+	if !ok {
+		t.Fatal("metadata should be GStreamMetadata type")
+	}
+
+	if metadata.Producer != "cms-xrootd-cache" {
+		t.Errorf("Producer = %v, expected cms-xrootd-cache", metadata.Producer)
+	}
+
+	if metadata.Type != "metric" {
+		t.Errorf("Type = %v, expected metric", metadata.Type)
+	}
+}
+
+func TestTransformCacheEvent(t *testing.T) {
+	raw := map[string]interface{}{
+		"event":      "file_close",
+		"lfn":        "/store/user/matevz/file.root",
+		"size":       float64(2446541517),
+		"blk_size":   float64(131072),
+		"n_blks":     float64(18666),
+		"n_blks_done": float64(6784),
+		"access_cnt": float64(4),
+		"attach_t":   float64(1688057096),
+		"detach_t":   float64(1688057104),
+		"b_hit":      float64(865075200),
+		"b_miss":     float64(24051712),
+		"b_bypass":   float64(0),
+		"n_cks_errs": float64(0),
+		"b_todisk":   float64(0),
+		"b_prefetch": float64(0),
+	}
+
+	result := TransformCacheEvent(raw)
+
+	// Verify renamed fields are present under new names
+	newNames := []string{
+		"file_path", "block_size", "numbers_blocks", "numbers_blocks_done",
+		"access_count", "attach_time", "detach_time", "bytes_hit_cache",
+		"bytes_miss_cache", "bytes_bypass_cache", "bytes_to_disk",
+		"bytes_by_prefetch", "numbers_checksum_errors",
+	}
+	for _, name := range newNames {
+		if _, ok := result[name]; !ok {
+			t.Errorf("expected field %q to be present in result", name)
+		}
+	}
+
+	// Verify old names are absent
+	oldNames := []string{
+		"lfn", "blk_size", "n_blks", "n_blks_done", "access_cnt",
+		"attach_t", "detach_t", "b_hit", "b_miss", "b_bypass",
+		"b_todisk", "b_prefetch", "n_cks_errs",
+	}
+	for _, name := range oldNames {
+		if _, ok := result[name]; ok {
+			t.Errorf("old field %q should not be present in result", name)
+		}
+	}
+
+	// Verify specific renamed values
+	if result["file_path"] != "/store/user/matevz/file.root" {
+		t.Errorf("file_path = %v, expected /store/user/matevz/file.root", result["file_path"])
+	}
+
+	// Verify derived fields (both b_todisk and b_bypass are 0)
+	if result["bytes_read_by_remote"] != float64(0) {
+		t.Errorf("bytes_read_by_remote = %v, expected 0", result["bytes_read_by_remote"])
+	}
+	if result["bytes_explicit_remote_read"] != float64(0) {
+		t.Errorf("bytes_explicit_remote_read = %v, expected 0", result["bytes_explicit_remote_read"])
+	}
+
+	// Verify unrelated fields pass through unchanged
+	if result["size"] != float64(2446541517) {
+		t.Errorf("size = %v, expected 2446541517", result["size"])
+	}
+	if result["event"] != "file_close" {
+		t.Errorf("event = %v, expected file_close", result["event"])
+	}
+
+	// Verify original is not mutated
+	if _, ok := raw["lfn"]; !ok {
+		t.Error("original map should not be mutated: lfn key missing")
+	}
+	if _, ok := raw["file_path"]; ok {
+		t.Error("original map should not be mutated: file_path key should not be added")
+	}
+}
+
+func TestTransformCacheEvent_DerivedFields(t *testing.T) {
+	raw := map[string]interface{}{
+		"b_todisk":   float64(1000),
+		"b_bypass":   float64(500),
+		"b_prefetch": float64(200),
+	}
+
+	result := TransformCacheEvent(raw)
+
+	if result["bytes_read_by_remote"] != float64(1500) {
+		t.Errorf("bytes_read_by_remote = %v, expected 1500", result["bytes_read_by_remote"])
+	}
+	if result["bytes_explicit_remote_read"] != float64(1300) {
+		t.Errorf("bytes_explicit_remote_read = %v, expected 1300", result["bytes_explicit_remote_read"])
+	}
+}
+
+func TestConvertGStreamToWLCG_TPC(t *testing.T) {
+	event := map[string]interface{}{
+		"source":      "root://src.cern.ch//store/data/file1.root",
+		"destination": "root://dst.cern.ch//store/data/file2.root",
+		"size":        int64(1000000),
+	}
+
+	wlcgEvent, err := ConvertGStreamToWLCG(event, true)
+	if err != nil {
+		t.Fatalf("ConvertGStreamToWLCG() error = %v", err)
+	}
+
+	metadata, ok := wlcgEvent["metadata"].(GStreamMetadata)
+	if !ok {
+		t.Fatal("metadata should be GStreamMetadata type")
+	}
+
+	if metadata.Type != "tpc" {
+		t.Errorf("Type = %v, expected tpc", metadata.Type)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -42,37 +42,39 @@ type OutputConfig struct {
 }
 
 type Config struct {
-	Input              InputConfig
-	State              StateConfig
-	Output             OutputConfig
-	Mode               string   // Operating mode: "shoveler" or "collector"
-	MQ                 string   // Which technology to use for the MQ connection
-	AmqpURL            *url.URL // AMQP URL (password comes from the token)
-	AmqpExchange       string   // Exchange to shovel file-close messages
-	AmqpExchangeCache  string   // Exchange for cache gstream events
-	AmqpExchangeTCP    string   // Exchange for TCP gstream events
-	AmqpExchangeTPC    string   // Exchange for TPC gstream events
-	AmqpExchangeWLCG   string   // Exchange for WLCG formatted events
-	AmqpToken          string   // File location of the token
-	AmqpPublishWorkers int      // Number of concurrent publishing workers
-	ListenPort         int
-	ListenIp           string
-	DestUdp            []string
-	Debug              bool
-	Verify             bool
-	StompUser          string
-	StompPassword      string
-	StompURL           *url.URL
-	StompTopic         string
-	Metrics            bool
-	MetricsPort        int
-	Profile            bool
-	ProfilePort        int
-	StompCert          string
-	StompCertKey       string
-	QueueDir           string
-	IpMapAll           string
-	IpMap              map[string]string
+	Input                 InputConfig
+	State                 StateConfig
+	Output                OutputConfig
+	Mode                  string   // Operating mode: "shoveler" or "collector"
+	MQ                    string   // Which technology to use for the MQ connection
+	AmqpURL               *url.URL // AMQP URL (password comes from the token)
+	AmqpExchange          string   // Exchange to shovel file-close messages
+	AmqpExchangeCache     string   // Exchange for cache gstream events
+	AmqpExchangeTCP       string   // Exchange for TCP gstream events
+	AmqpExchangeTPC       string   // Exchange for TPC gstream events
+	AmqpExchangeWLCG      string   // Exchange for WLCG formatted events
+	AmqpExchangeWLCGCache string   // Exchange for WLCG formatted cache gstream events
+	AmqpExchangeWLCGTPC   string   // Exchange for WLCG formatted TPC events
+	AmqpToken             string   // File location of the token
+	AmqpPublishWorkers    int      // Number of concurrent publishing workers
+	ListenPort            int
+	ListenIp              string
+	DestUdp               []string
+	Debug                 bool
+	Verify                bool
+	StompUser             string
+	StompPassword         string
+	StompURL              *url.URL
+	StompTopic            string
+	Metrics               bool
+	MetricsPort           int
+	Profile               bool
+	ProfilePort           int
+	StompCert             string
+	StompCertKey          string
+	QueueDir              string
+	IpMapAll              string
+	IpMap                 map[string]string
 }
 
 func (c *Config) ReadConfig() {
@@ -208,6 +210,14 @@ func (c *Config) ReadConfigWithPathAndPrefix(configPath string, envPrefix string
 		viper.SetDefault("amqp.exchange_wlcg", "xrd-wlcg-events")
 		c.AmqpExchangeWLCG = viper.GetString("amqp.exchange_wlcg")
 		log.Debugln("AMQP WLCG Exchange:", c.AmqpExchangeWLCG)
+
+		viper.SetDefault("amqp.exchange_wlcg_cache", "xrd-wlcg-cache-events")
+		c.AmqpExchangeWLCGCache = viper.GetString("amqp.exchange_wlcg_cache")
+		log.Debugln("AMQP WLCG Cache Exchange:", c.AmqpExchangeWLCGCache)
+
+		viper.SetDefault("amqp.exchange_wlcg_tpc", "xrd-wlcg-tpc-events")
+		c.AmqpExchangeWLCGTPC = viper.GetString("amqp.exchange_wlcg_tpc")
+		log.Debugln("AMQP WLCG TPC Exchange:", c.AmqpExchangeWLCGTPC)
 
 		// Get the Token location
 		c.AmqpToken = viper.GetString("amqp.token_location")


### PR DESCRIPTION
## Summary

- Raw XRootD gstream JSON uses short field names (`lfn`, `b_hit`, `Src`, `Dst`, etc.) that the WLCG routing code never saw because it checked for already-renamed names (`file_path`, `source`, `destination`)
- WLCG routing for cache and TPC events was silently broken — the path checks never matched, so all events went to the non-WLCG exchanges
- Add `TransformCacheEvent` and `TransformTPCEvent` (mirroring Python `DetailedCollector.process_gstream` / `process_gstream_tpc`) and wire them into `emitGStreamEvent` before path checks and publishing

## Changes

- `collector/wlcg_converter.go`: Add `TransformCacheEvent` (13 field renames + 2 derived byte fields), `TransformTPCEvent` (5 top-level + 6 nested `Xeq` renames), and unexported helpers `renameField` / `toFloat64`
- `collector/wlcg_converter_test.go`: Tests for both transform functions using raw XRootD field names as input
- `cmd/collector/main.go`: Call `TransformCacheEvent`/`TransformTPCEvent` at the top of each case in `emitGStreamEvent` so routing and published events use the correct renamed fields

## Test plan

- [ ] `go test ./... -short` passes
- [ ] Cache events with `/store` or `/user/dteam` paths now route to `amqp.exchange_wlcg_cache` with renamed fields
- [ ] TPC events with WLCG source/destination now route to `amqp.exchange_wlcg_tpc` with renamed fields
- [ ] Non-WLCG cache and TPC events still route to their respective non-WLCG exchanges

🤖 Generated with [Claude Code](https://claude.com/claude-code)