### PR TITLE
feat(collector): configurable WLCG routing and record drop filter

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -269,6 +269,10 @@ func buildCorrelatorConfig(config *shoveler.Config, logger *logrus.Logger) colle
 		EnrichmentWorkers:   config.State.EnrichmentWorkers,
 		EnrichmentQueueSize: config.State.EnrichmentQueueSize,
 		Logger:              logger,
+		WLCGVOs:             config.WLCG.VOs,
+		WLCGPathPrefixes:    config.WLCG.PathPrefixes,
+		DropPathPrefixes:    config.Filter.DropPathPrefixes,
+		DropVOs:             config.Filter.DropVOs,
 	}
 
 	return correlatorConfig

--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -161,7 +161,7 @@ type CorrelatorConfig struct {
 
 	// WLCG routing: records matching any VO (case-insensitive) or path prefix are
 	// converted and routed to the WLCG exchange. Defaults to ["cms"] and
-	// ["/store", "/user/dteam"] when left empty.
+	// ["/store", "/user/dteam"] when left unset.
 	WLCGVOs          []string
 	WLCGPathPrefixes []string
 
@@ -205,11 +205,11 @@ func NewCorrelatorWithConfig(config CorrelatorConfig) *Correlator {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	wlcgVOs := config.WLCGVOs
-	if len(wlcgVOs) == 0 {
+	if wlcgVOs == nil {
 		wlcgVOs = defaultWLCGVOs
 	}
 	wlcgPathPrefixes := config.WLCGPathPrefixes
-	if len(wlcgPathPrefixes) == 0 {
+	if wlcgPathPrefixes == nil {
 		wlcgPathPrefixes = defaultWLCGPathPrefixes
 	}
 

--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -138,6 +138,14 @@ type Correlator struct {
 	enrichmentDropCount   int64 // atomic; counts records dropped due to full queue
 	ctx                   context.Context
 	cancel                context.CancelFunc
+
+	// WLCG routing configuration
+	wlcgVOs          []string
+	wlcgPathPrefixes []string
+
+	// Record drop filter
+	dropPathPrefixes []string
+	dropVOs          []string
 }
 
 // CorrelatorConfig holds configuration for the correlator including DNS enrichment
@@ -150,6 +158,17 @@ type CorrelatorConfig struct {
 	EnrichmentWorkers   int // Number of enrichment worker goroutines (default: 5)
 	EnrichmentQueueSize int // Maximum number of pending enrichment requests (default: 1000000)
 	Logger              *logrus.Logger
+
+	// WLCG routing: records matching any VO (case-insensitive) or path prefix are
+	// converted and routed to the WLCG exchange. Defaults to ["cms"] and
+	// ["/store", "/user/dteam"] when left empty.
+	WLCGVOs          []string
+	WLCGPathPrefixes []string
+
+	// Drop filter: records matching any VO (case-insensitive) or path prefix are
+	// silently dropped before any publish. Defaults to empty (drop nothing).
+	DropPathPrefixes []string
+	DropVOs          []string
 }
 
 // NewCorrelator creates a new correlator
@@ -185,6 +204,15 @@ func NewCorrelatorWithConfig(config CorrelatorConfig) *Correlator {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	wlcgVOs := config.WLCGVOs
+	if len(wlcgVOs) == 0 {
+		wlcgVOs = defaultWLCGVOs
+	}
+	wlcgPathPrefixes := config.WLCGPathPrefixes
+	if len(wlcgPathPrefixes) == 0 {
+		wlcgPathPrefixes = defaultWLCGPathPrefixes
+	}
+
 	c := &Correlator{
 		stateMap:              NewStateMap(config.TTL, config.MaxEntries, config.TTL/10),
 		userMap:               NewStateMap(config.TTL, config.MaxEntries, config.TTL/10),
@@ -198,6 +226,10 @@ func NewCorrelatorWithConfig(config CorrelatorConfig) *Correlator {
 		enrichmentQueueSize:   config.EnrichmentQueueSize,
 		ctx:                   ctx,
 		cancel:                cancel,
+		wlcgVOs:               wlcgVOs,
+		wlcgPathPrefixes:      wlcgPathPrefixes,
+		dropPathPrefixes:      config.DropPathPrefixes,
+		dropVOs:               config.DropVOs,
 	}
 
 	if config.EnableDNSEnrichment {

--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -207,11 +207,11 @@ func NewCorrelatorWithConfig(config CorrelatorConfig) *Correlator {
 
 	wlcgVOs := config.WLCGVOs
 	if wlcgVOs == nil {
-		wlcgVOs = defaultWLCGVOs
+		wlcgVOs = append([]string(nil), defaultWLCGVOs...)
 	}
 	wlcgPathPrefixes := config.WLCGPathPrefixes
 	if wlcgPathPrefixes == nil {
-		wlcgPathPrefixes = defaultWLCGPathPrefixes
+		wlcgPathPrefixes = append([]string(nil), defaultWLCGPathPrefixes...)
 	}
 
 	c := &Correlator{

--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -160,8 +160,9 @@ type CorrelatorConfig struct {
 	Logger              *logrus.Logger
 
 	// WLCG routing: records matching any VO (case-insensitive) or path prefix are
-	// converted and routed to the WLCG exchange. Defaults to ["cms"] and
-	// ["/store", "/user/dteam"] when left unset.
+	// converted and routed to the WLCG exchange.
+	// If WLCGVOs/WLCGPathPrefixes are nil, defaults apply (["cms"], ["/store", "/user/dteam"]).
+	// If they are non-nil but empty, WLCG routing is effectively disabled.
 	WLCGVOs          []string
 	WLCGPathPrefixes []string
 

--- a/collector/enrichment.go
+++ b/collector/enrichment.go
@@ -237,6 +237,12 @@ func (c *Correlator) enrichmentWorker() {
 }
 
 func (c *Correlator) processEnrichmentRequest(req enrichmentRequest) {
+	// Drop filter runs first — a matching record is published to neither exchange.
+	if drop, reason := c.shouldDrop(req.record); drop {
+		recordsDropped.WithLabelValues(reason).Inc()
+		return
+	}
+
 	for _, enricher := range c.enrichers {
 		enricher.Enrich(c.ctx, req.record)
 	}
@@ -254,7 +260,7 @@ func (c *Correlator) processEnrichmentRequest(req enrichmentRequest) {
 }
 
 func (c *Correlator) buildEnrichedRecord(record *CollectorRecord, wlcgExchange string) (EnrichedRecord, error) {
-	if IsWLCGPacket(record) {
+	if c.matchesWLCG(record) {
 		wlcgRecord, err := ConvertToWLCG(record)
 		if err != nil {
 			return EnrichedRecord{}, err

--- a/collector/filter.go
+++ b/collector/filter.go
@@ -1,0 +1,66 @@
+package collector
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Default WLCG matching values — preserved from the original hardcoded logic.
+var (
+	defaultWLCGVOs          = []string{"cms"}
+	defaultWLCGPathPrefixes = []string{"/store", "/user/dteam"}
+)
+
+// recordsDropped counts records silently dropped by the filter before publishing.
+// The "reason" label is either "vo" or "path_prefix".
+var recordsDropped = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "shoveler_records_dropped_total",
+	Help: "Total number of records dropped by the filter before publishing, labeled by reason (vo or path_prefix)",
+}, []string{"reason"})
+
+// matchesWLCG returns true when the record should be routed to the WLCG exchange.
+// It checks c.wlcgVOs (case-insensitive exact match) and c.wlcgPathPrefixes (HasPrefix).
+func (c *Correlator) matchesWLCG(record *CollectorRecord) bool {
+	recordVO := strings.ToLower(strings.TrimSpace(record.VO))
+	if recordVO != "" {
+		for _, vo := range c.wlcgVOs {
+			if strings.ToLower(strings.TrimSpace(vo)) == recordVO {
+				return true
+			}
+		}
+	}
+
+	filename := strings.TrimSpace(record.Filename)
+	for _, prefix := range c.wlcgPathPrefixes {
+		if prefix != "" && strings.HasPrefix(filename, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// shouldDrop returns (true, reason) when the record matches the drop filter and
+// must be discarded before any publish. Reason is "vo" or "path_prefix".
+// An empty filter (nil or empty slices) never drops anything.
+func (c *Correlator) shouldDrop(record *CollectorRecord) (bool, string) {
+	recordVO := strings.ToLower(strings.TrimSpace(record.VO))
+	if recordVO != "" {
+		for _, vo := range c.dropVOs {
+			if vo != "" && strings.ToLower(strings.TrimSpace(vo)) == recordVO {
+				return true, "vo"
+			}
+		}
+	}
+
+	filename := strings.TrimSpace(record.Filename)
+	for _, prefix := range c.dropPathPrefixes {
+		if prefix != "" && strings.HasPrefix(filename, prefix) {
+			return true, "path_prefix"
+		}
+	}
+
+	return false, ""
+}

--- a/collector/filter.go
+++ b/collector/filter.go
@@ -23,9 +23,13 @@ var recordsDropped = promauto.NewCounterVec(prometheus.CounterOpts{
 // matchesWLCG returns true when the record should be routed to the WLCG exchange.
 // It checks c.wlcgVOs (case-insensitive exact match) and c.wlcgPathPrefixes (HasPrefix).
 func (c *Correlator) matchesWLCG(record *CollectorRecord) bool {
+	return matchesWLCGWithRules(record, c.wlcgVOs, c.wlcgPathPrefixes)
+}
+
+func matchesWLCGWithRules(record *CollectorRecord, wlcgVOs, wlcgPathPrefixes []string) bool {
 	recordVO := strings.ToLower(strings.TrimSpace(record.VO))
 	if recordVO != "" {
-		for _, vo := range c.wlcgVOs {
+		for _, vo := range wlcgVOs {
 			if strings.ToLower(strings.TrimSpace(vo)) == recordVO {
 				return true
 			}
@@ -33,7 +37,7 @@ func (c *Correlator) matchesWLCG(record *CollectorRecord) bool {
 	}
 
 	filename := strings.TrimSpace(record.Filename)
-	for _, prefix := range c.wlcgPathPrefixes {
+	for _, prefix := range wlcgPathPrefixes {
 		prefix = strings.TrimSpace(prefix)
 		if prefix != "" && strings.HasPrefix(filename, prefix) {
 			return true

--- a/collector/filter.go
+++ b/collector/filter.go
@@ -16,8 +16,8 @@ var (
 // recordsDropped counts records silently dropped by the filter before publishing.
 // The "reason" label is either "vo" or "path_prefix".
 var recordsDropped = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "shoveler_records_dropped_total",
-	Help: "Total number of records dropped by the filter before publishing, labeled by reason (vo or path_prefix)",
+	Name: "shoveler_records_dropped",
+	Help: "The total number of records dropped by the filter before publishing, labeled by reason (vo or path_prefix)",
 }, []string{"reason"})
 
 // matchesWLCG returns true when the record should be routed to the WLCG exchange.

--- a/collector/filter.go
+++ b/collector/filter.go
@@ -34,6 +34,7 @@ func (c *Correlator) matchesWLCG(record *CollectorRecord) bool {
 
 	filename := strings.TrimSpace(record.Filename)
 	for _, prefix := range c.wlcgPathPrefixes {
+		prefix = strings.TrimSpace(prefix)
 		if prefix != "" && strings.HasPrefix(filename, prefix) {
 			return true
 		}
@@ -57,6 +58,7 @@ func (c *Correlator) shouldDrop(record *CollectorRecord) (bool, string) {
 
 	filename := strings.TrimSpace(record.Filename)
 	for _, prefix := range c.dropPathPrefixes {
+		prefix = strings.TrimSpace(prefix)
 		if prefix != "" && strings.HasPrefix(filename, prefix) {
 			return true, "path_prefix"
 		}

--- a/collector/filter_test.go
+++ b/collector/filter_test.go
@@ -8,12 +8,8 @@ import (
 )
 
 // newTestCorrelator creates a minimal correlator suitable for filter tests.
-// It starts no enrichment workers so processEnrichmentRequest can be called
-// synchronously via a direct call.
 func newTestCorrelator(cfg CorrelatorConfig) *Correlator {
-	// Ensure logger is set
-	c := NewCorrelatorWithConfig(cfg)
-	return c
+	return NewCorrelatorWithConfig(cfg)
 }
 
 // ---- WLCG match tests -------------------------------------------------------
@@ -24,7 +20,7 @@ func TestMatchesWLCG_DefaultConfig(t *testing.T) {
 	c := newTestCorrelator(CorrelatorConfig{
 		TTL:    time.Minute,
 		Logger: nil,
-		// WLCGVOs and WLCGPathPrefixes intentionally left empty → defaults apply
+		// WLCGVOs and WLCGPathPrefixes intentionally left unset → defaults apply
 	})
 	defer c.Stop()
 
@@ -75,11 +71,42 @@ func TestMatchesWLCG_DefaultConfig(t *testing.T) {
 	}
 }
 
+func TestMatchesWLCG_ExplicitEmptyConfigDisablesDefaults(t *testing.T) {
+	c := newTestCorrelator(CorrelatorConfig{
+		TTL:              time.Minute,
+		WLCGVOs:          []string{},
+		WLCGPathPrefixes: []string{},
+	})
+	defer c.Stop()
+
+	tests := []struct {
+		name   string
+		record *CollectorRecord
+	}{
+		{
+			name:   "default VO cms no longer matches",
+			record: &CollectorRecord{VO: "cms", Filename: "/other/path"},
+		},
+		{
+			name:   "default path /store no longer matches",
+			record: &CollectorRecord{VO: "osg", Filename: "/store/data/file.root"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if c.matchesWLCG(tt.record) {
+				t.Errorf("matchesWLCG() = true, want false")
+			}
+		})
+	}
+}
+
 func TestMatchesWLCG_CustomConfig(t *testing.T) {
 	c := newTestCorrelator(CorrelatorConfig{
 		TTL:              time.Minute,
 		WLCGVOs:          []string{"atlas", "lhcb"},
-		WLCGPathPrefixes: []string{"/eos/atlas"},
+		WLCGPathPrefixes: []string{"/eos/atlas "},
 	})
 	defer c.Stop()
 
@@ -212,7 +239,7 @@ func TestShouldDrop_ByVO(t *testing.T) {
 func TestShouldDrop_ByPathPrefix(t *testing.T) {
 	c := newTestCorrelator(CorrelatorConfig{
 		TTL:              time.Minute,
-		DropPathPrefixes: []string{"/eos"},
+		DropPathPrefixes: []string{"/eos "},
 	})
 	defer c.Stop()
 

--- a/collector/filter_test.go
+++ b/collector/filter_test.go
@@ -1,0 +1,401 @@
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// newTestCorrelator creates a minimal correlator suitable for filter tests.
+// It starts no enrichment workers so processEnrichmentRequest can be called
+// synchronously via a direct call.
+func newTestCorrelator(cfg CorrelatorConfig) *Correlator {
+	// Ensure logger is set
+	c := NewCorrelatorWithConfig(cfg)
+	return c
+}
+
+// ---- WLCG match tests -------------------------------------------------------
+
+func TestMatchesWLCG_DefaultConfig(t *testing.T) {
+	// A correlator with empty WLCG config must fall back to the defaults
+	// and behave identically to the hardcoded IsWLCGPacket function.
+	c := newTestCorrelator(CorrelatorConfig{
+		TTL:    time.Minute,
+		Logger: nil,
+		// WLCGVOs and WLCGPathPrefixes intentionally left empty → defaults apply
+	})
+	defer c.Stop()
+
+	tests := []struct {
+		name     string
+		record   *CollectorRecord
+		expected bool
+	}{
+		{
+			name:     "default VO cms",
+			record:   &CollectorRecord{VO: "cms", Filename: "/other/path"},
+			expected: true,
+		},
+		{
+			name:     "default VO cms case-insensitive upper",
+			record:   &CollectorRecord{VO: "CMS", Filename: "/other/path"},
+			expected: true,
+		},
+		{
+			name:     "default path /store",
+			record:   &CollectorRecord{VO: "atlas", Filename: "/store/data/file.root"},
+			expected: true,
+		},
+		{
+			name:     "default path /user/dteam",
+			record:   &CollectorRecord{VO: "other", Filename: "/user/dteam/test.dat"},
+			expected: true,
+		},
+		{
+			name:     "no match",
+			record:   &CollectorRecord{VO: "osg", Filename: "/ospool/data.txt"},
+			expected: false,
+		},
+		{
+			name:     "empty VO and filename",
+			record:   &CollectorRecord{VO: "", Filename: ""},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.matchesWLCG(tt.record)
+			if got != tt.expected {
+				t.Errorf("matchesWLCG() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMatchesWLCG_CustomConfig(t *testing.T) {
+	c := newTestCorrelator(CorrelatorConfig{
+		TTL:              time.Minute,
+		WLCGVOs:          []string{"atlas", "lhcb"},
+		WLCGPathPrefixes: []string{"/eos/atlas"},
+	})
+	defer c.Stop()
+
+	tests := []struct {
+		name     string
+		record   *CollectorRecord
+		expected bool
+	}{
+		{
+			name:     "VO atlas hit",
+			record:   &CollectorRecord{VO: "atlas", Filename: "/other"},
+			expected: true,
+		},
+		{
+			name:     "VO atlas case-insensitive",
+			record:   &CollectorRecord{VO: "ATLAS", Filename: "/other"},
+			expected: true,
+		},
+		{
+			name:     "VO lhcb hit",
+			record:   &CollectorRecord{VO: "lhcb", Filename: "/other"},
+			expected: true,
+		},
+		{
+			name:     "path /eos/atlas hit",
+			record:   &CollectorRecord{VO: "cms", Filename: "/eos/atlas/file"},
+			expected: true,
+		},
+		{
+			name:     "VO cms no longer matches (not in custom list)",
+			record:   &CollectorRecord{VO: "cms", Filename: "/other/path"},
+			expected: false,
+		},
+		{
+			name:     "path /store no longer matches (not in custom list)",
+			record:   &CollectorRecord{VO: "osg", Filename: "/store/data/file.root"},
+			expected: false,
+		},
+		{
+			name:     "no match",
+			record:   &CollectorRecord{VO: "osg", Filename: "/ospool/data.txt"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.matchesWLCG(tt.record)
+			if got != tt.expected {
+				t.Errorf("matchesWLCG() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// ---- Drop filter tests ------------------------------------------------------
+
+func TestShouldDrop_EmptyConfig(t *testing.T) {
+	// An unconfigured filter must never drop anything.
+	c := newTestCorrelator(CorrelatorConfig{
+		TTL: time.Minute,
+		// DropVOs and DropPathPrefixes intentionally left nil
+	})
+	defer c.Stop()
+
+	records := []*CollectorRecord{
+		{VO: "cms", Filename: "/store/data/file.root"},
+		{VO: "atlas", Filename: "/eos/atlas/data"},
+		{VO: "", Filename: ""},
+	}
+
+	for _, r := range records {
+		drop, _ := c.shouldDrop(r)
+		if drop {
+			t.Errorf("shouldDrop() returned true for %+v with empty config", r)
+		}
+	}
+}
+
+func TestShouldDrop_ByVO(t *testing.T) {
+	c := newTestCorrelator(CorrelatorConfig{
+		TTL:     time.Minute,
+		DropVOs: []string{"atlas"},
+	})
+	defer c.Stop()
+
+	tests := []struct {
+		name       string
+		record     *CollectorRecord
+		wantDrop   bool
+		wantReason string
+	}{
+		{
+			name:       "drop atlas",
+			record:     &CollectorRecord{VO: "atlas", Filename: "/eos/atlas/data"},
+			wantDrop:   true,
+			wantReason: "vo",
+		},
+		{
+			name:       "drop atlas case-insensitive",
+			record:     &CollectorRecord{VO: "ATLAS", Filename: "/eos/atlas/data"},
+			wantDrop:   true,
+			wantReason: "vo",
+		},
+		{
+			name:     "cms not dropped",
+			record:   &CollectorRecord{VO: "cms", Filename: "/store/data/file.root"},
+			wantDrop: false,
+		},
+		{
+			name:     "empty VO not dropped",
+			record:   &CollectorRecord{VO: "", Filename: "/store/data/file.root"},
+			wantDrop: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			drop, reason := c.shouldDrop(tt.record)
+			if drop != tt.wantDrop {
+				t.Errorf("shouldDrop() drop = %v, want %v", drop, tt.wantDrop)
+			}
+			if tt.wantDrop && reason != tt.wantReason {
+				t.Errorf("shouldDrop() reason = %q, want %q", reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestShouldDrop_ByPathPrefix(t *testing.T) {
+	c := newTestCorrelator(CorrelatorConfig{
+		TTL:              time.Minute,
+		DropPathPrefixes: []string{"/eos"},
+	})
+	defer c.Stop()
+
+	tests := []struct {
+		name       string
+		record     *CollectorRecord
+		wantDrop   bool
+		wantReason string
+	}{
+		{
+			name:       "drop /eos path",
+			record:     &CollectorRecord{VO: "atlas", Filename: "/eos/atlas/data"},
+			wantDrop:   true,
+			wantReason: "path_prefix",
+		},
+		{
+			name:       "drop /eos/cms path",
+			record:     &CollectorRecord{VO: "cms", Filename: "/eos/cms/run3/file.root"},
+			wantDrop:   true,
+			wantReason: "path_prefix",
+		},
+		{
+			name:     "/store not dropped",
+			record:   &CollectorRecord{VO: "cms", Filename: "/store/data/file.root"},
+			wantDrop: false,
+		},
+		{
+			name:     "empty filename not dropped",
+			record:   &CollectorRecord{VO: "atlas", Filename: ""},
+			wantDrop: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			drop, reason := c.shouldDrop(tt.record)
+			if drop != tt.wantDrop {
+				t.Errorf("shouldDrop() drop = %v, want %v", drop, tt.wantDrop)
+			}
+			if tt.wantDrop && reason != tt.wantReason {
+				t.Errorf("shouldDrop() reason = %q, want %q", reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// ---- Integration: drop filter blocks publish --------------------------------
+
+// TestDropFilterBlocksPublish verifies that a record matching the drop filter
+// is sent to neither the main exchange nor the WLCG exchange.
+func TestDropFilterBlocksPublish(t *testing.T) {
+	c := newTestCorrelator(CorrelatorConfig{
+		TTL:              time.Minute,
+		DropPathPrefixes: []string{"/eos"},
+		// Also configure WLCG so the record *would* match it via VO if not dropped
+		WLCGVOs: []string{"cms"},
+	})
+	defer c.Stop()
+
+	resultCh := make(chan EnrichedRecord, 1)
+	dest := EnrichmentDestination{
+		Results:      resultCh,
+		WLCGExchange: "wlcg-exchange",
+	}
+
+	// This record matches the drop filter (/eos prefix) and would also match
+	// the WLCG VO (cms). Drop must win.
+	record := &CollectorRecord{
+		VO:       "cms",
+		Filename: "/eos/cms/run3/file.root",
+	}
+
+	req := enrichmentRequest{record: record, destination: dest}
+	c.processEnrichmentRequest(req)
+
+	// Nothing should be sent to the result channel.
+	select {
+	case got := <-resultCh:
+		t.Errorf("expected no publish but got record on exchange %q", got.Exchange)
+	default:
+		// correct: nothing published
+	}
+}
+
+// TestDropPrecedenceOverWLCG verifies that a record matching both the drop
+// filter (by VO) and the WLCG filter (by path) is dropped, not published.
+func TestDropPrecedenceOverWLCG(t *testing.T) {
+	c := newTestCorrelator(CorrelatorConfig{
+		TTL:              time.Minute,
+		WLCGPathPrefixes: []string{"/store"},
+		DropVOs:          []string{"cms"},
+	})
+	defer c.Stop()
+
+	resultCh := make(chan EnrichedRecord, 1)
+	dest := EnrichmentDestination{
+		Results:      resultCh,
+		WLCGExchange: "wlcg-exchange",
+	}
+
+	record := &CollectorRecord{
+		VO:       "cms",       // matches drop filter
+		Filename: "/store/x",  // would match WLCG path prefix
+	}
+
+	req := enrichmentRequest{record: record, destination: dest}
+	c.processEnrichmentRequest(req)
+
+	select {
+	case got := <-resultCh:
+		t.Errorf("expected drop but record was published to exchange %q", got.Exchange)
+	default:
+		// correct
+	}
+}
+
+// TestNonDroppedRecordIsPublished verifies that a record that does NOT match
+// the drop filter is still published (to the main or WLCG exchange).
+func TestNonDroppedRecordIsPublished(t *testing.T) {
+	c := newTestCorrelator(CorrelatorConfig{
+		TTL:              time.Minute,
+		DropPathPrefixes: []string{"/eos"},
+		WLCGVOs:          []string{"cms"},
+	})
+	defer c.Stop()
+
+	resultCh := make(chan EnrichedRecord, 1)
+	dest := EnrichmentDestination{
+		Results:      resultCh,
+		WLCGExchange: "wlcg-exchange",
+	}
+
+	// cms VO matches WLCG, path does not match drop filter
+	record := &CollectorRecord{
+		VO:       "cms",
+		Filename: "/store/data/file.root",
+		Site:     "T2_US_Nebraska",
+	}
+
+	req := enrichmentRequest{record: record, destination: dest}
+	c.processEnrichmentRequest(req)
+
+	select {
+	case got := <-resultCh:
+		if got.Exchange != "wlcg-exchange" {
+			t.Errorf("expected wlcg-exchange, got %q", got.Exchange)
+		}
+		var parsed map[string]interface{}
+		if err := json.Unmarshal(got.Payload, &parsed); err != nil {
+			t.Fatalf("payload is not valid JSON: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for published record")
+	}
+}
+
+// TestDropFilterWithEnrichmentPipeline verifies drop via the full async
+// enrichment pipeline (EnqueueForEnrichment), not just processEnrichmentRequest.
+func TestDropFilterWithEnrichmentPipeline(t *testing.T) {
+	c := newTestCorrelator(CorrelatorConfig{
+		TTL:              time.Minute,
+		EnrichmentWorkers: 1,
+		DropVOs:          []string{"droppedvo"},
+	})
+	defer c.Stop()
+
+	resultCh := make(chan EnrichedRecord, 1)
+	dest := EnrichmentDestination{
+		Results:      resultCh,
+		WLCGExchange: "wlcg-exchange",
+	}
+
+	record := &CollectorRecord{VO: "droppedvo", Filename: "/some/path"}
+	c.EnqueueForEnrichment(record, dest)
+
+	// Give workers time to process.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	select {
+	case got := <-resultCh:
+		t.Errorf("dropped record was published to exchange %q", got.Exchange)
+	case <-ctx.Done():
+		// correct: nothing published within timeout
+	}
+}

--- a/collector/filter_test.go
+++ b/collector/filter_test.go
@@ -71,6 +71,23 @@ func TestMatchesWLCG_DefaultConfig(t *testing.T) {
 	}
 }
 
+func TestMatchesWLCG_DefaultConfigCopiesDefaultSlices(t *testing.T) {
+	c := newTestCorrelator(CorrelatorConfig{
+		TTL: time.Minute,
+	})
+	defer c.Stop()
+
+	c.wlcgVOs[0] = "atlas"
+	c.wlcgPathPrefixes[0] = "/eos/atlas"
+
+	if defaultWLCGVOs[0] != "cms" {
+		t.Fatalf("defaultWLCGVOs was mutated: got %q, want %q", defaultWLCGVOs[0], "cms")
+	}
+	if defaultWLCGPathPrefixes[0] != "/store" {
+		t.Fatalf("defaultWLCGPathPrefixes was mutated: got %q, want %q", defaultWLCGPathPrefixes[0], "/store")
+	}
+}
+
 func TestMatchesWLCG_ExplicitEmptyConfigDisablesDefaults(t *testing.T) {
 	c := newTestCorrelator(CorrelatorConfig{
 		TTL:              time.Minute,

--- a/collector/wlcg_converter.go
+++ b/collector/wlcg_converter.go
@@ -72,22 +72,12 @@ type WLCGRecord struct {
 }
 
 // IsWLCGPacket determines if a record should be converted to WLCG format
-// Based on reference implementation:
-// - Path starts with /store or /user/dteam
-// - VO is "cms"
+// using the default routing rules from the reference implementation.
+//
+// Deprecated: runtime routing uses CorrelatorConfig (WLCGVOs/WLCGPathPrefixes)
+// and may differ when those values are overridden.
 func IsWLCGPacket(record *CollectorRecord) bool {
-	// Check if VO is cms
-	if strings.EqualFold(record.VO, "cms") {
-		return true
-	}
-
-	// Check if path starts with /store or /user/dteam
-	filename := strings.TrimSpace(record.Filename)
-	if strings.HasPrefix(filename, "/store") || strings.HasPrefix(filename, "/user/dteam") {
-		return true
-	}
-
-	return false
+	return matchesWLCGWithRules(record, defaultWLCGVOs, defaultWLCGPathPrefixes)
 }
 
 // ConvertToWLCG converts a CollectorRecord to WLCG format

--- a/config.go
+++ b/config.go
@@ -8,6 +8,16 @@ import (
 	"github.com/spf13/viper"
 )
 
+type WLCGConfig struct {
+	VOs          []string // case-insensitive exact match; defaults to ["cms"]
+	PathPrefixes []string // HasPrefix match; defaults to ["/store", "/user/dteam"]
+}
+
+type FilterConfig struct {
+	DropPathPrefixes []string // records whose path matches any prefix are dropped entirely
+	DropVOs          []string // records whose VO matches (case-insensitive) are dropped entirely
+}
+
 type InputConfig struct {
 	Type          string // "udp", "file", or "rabbitmq"
 	Host          string
@@ -79,6 +89,8 @@ type Config struct {
 	QueueDir              string
 	IpMapAll              string
 	IpMap                 map[string]string
+	WLCG                  WLCGConfig
+	Filter                FilterConfig
 }
 
 func (c *Config) ReadConfig() {
@@ -303,4 +315,15 @@ func (c *Config) ReadConfigWithPathAndPrefix(configPath string, envPrefix string
 
 	// If the map is not set
 	c.IpMap = viper.GetStringMapString("map")
+
+	// WLCG routing configuration (collector mode only)
+	// Defaults preserve current behavior: CMS VO and /store, /user/dteam paths.
+	viper.SetDefault("wlcg.vos", []string{"cms"})
+	viper.SetDefault("wlcg.path_prefixes", []string{"/store", "/user/dteam"})
+	c.WLCG.VOs = viper.GetStringSlice("wlcg.vos")
+	c.WLCG.PathPrefixes = viper.GetStringSlice("wlcg.path_prefixes")
+
+	// Record drop filter (collector mode only); defaults to drop nothing.
+	c.Filter.DropPathPrefixes = viper.GetStringSlice("filter.drop_path_prefixes")
+	c.Filter.DropVOs = viper.GetStringSlice("filter.drop_vos")
 }

--- a/config/config-collector.yaml
+++ b/config/config-collector.yaml
@@ -43,8 +43,7 @@ state:
 # Records matching any VO (case-insensitive) OR any path prefix are dropped
 # entirely — published to neither the main exchange nor the WLCG exchange.
 # The drop filter is evaluated before WLCG routing.
-# A Prometheus counter (shoveler_records_dropped_total{reason="vo|path_prefix"})
-# tracks dropped records.
+# A Prometheus counter (shoveler_records_dropped{reason="vo|path_prefix"})
 # Default is to drop nothing (empty lists).
 # filter:
 #   drop_vos: []

--- a/config/config-collector.yaml
+++ b/config/config-collector.yaml
@@ -31,6 +31,25 @@ state:
   # gstream_queue_size: 20000 # Max pending gstream packets kept in memory
   # dns_timeout: 2            # DNS lookup timeout in seconds
 
+# WLCG routing configuration (collector mode only)
+# Records matching any VO (case-insensitive) OR any path prefix are converted to
+# WLCG format and published to the WLCG exchange instead of the main exchange.
+# Omitting this block preserves the current default behavior.
+# wlcg:
+#   vos: ["cms"]                              # default
+#   path_prefixes: ["/store", "/user/dteam"]  # default
+
+# Record drop filter (collector mode only)
+# Records matching any VO (case-insensitive) OR any path prefix are dropped
+# entirely — published to neither the main exchange nor the WLCG exchange.
+# The drop filter is evaluated before WLCG routing.
+# A Prometheus counter (shoveler_records_dropped_total{reason="vo|path_prefix"})
+# tracks dropped records.
+# Default is to drop nothing (empty lists).
+# filter:
+#   drop_vos: []
+#   drop_path_prefixes: []
+
 # Select which protocol to use in order to connect to the MQ
 # mq: amqp/stomp
 


### PR DESCRIPTION
Closes #94

## Summary

Replaces two pieces of hardcoded logic in the collector's WLCG conversion path with configurable alternatives.

### Feature 1 — Configurable WLCG matching

```yaml
wlcg:
  vos: ["cms"]                              # OR-combined, case-insensitive exact match
  path_prefixes: ["/store", "/user/dteam"]  # OR-combined, HasPrefix
```

Records whose VO is in `vos` **or** whose path starts with any entry in `path_prefixes` are converted to WLCG format and published to the WLCG exchange. This is exactly the current behaviour. If the `wlcg:` block is absent the defaults kick in, so existing deployments are unaffected.

### Feature 2 — Configurable drop filter

```yaml
filter:
  drop_vos: []           # default: drop nothing
  drop_path_prefixes: [] # default: drop nothing
```

Evaluated **before** WLCG routing. A matching record is published to neither the main exchange nor the WLCG exchange. A new Prometheus counter tracks every drop:

```
shoveler_records_dropped_total{reason="vo|path_prefix"}
```

## Files changed

| File | What changed |
|------|-------------|
| `config.go` | New `WLCGConfig` and `FilterConfig` structs; added to `Config`; viper `SetDefault` wires defaults |
| `collector/correlator.go` | `CorrelatorConfig` gains `WLCGVOs`, `WLCGPathPrefixes`, `DropPathPrefixes`, `DropVOs`; `Correlator` stores them; `NewCorrelatorWithConfig` applies defaults |
| `collector/filter.go` *(new)* | `matchesWLCG` and `shouldDrop` methods on `Correlator`; default constants; `shoveler_records_dropped_total` counter |
| `collector/enrichment.go` | Drop check before enrichment; `c.matchesWLCG()` replaces the hardcoded `IsWLCGPacket()` call in `buildEnrichedRecord` |
| `collector/filter_test.go` *(new)* | Unit tests for WLCG match (VO hit, path hit, case-insensitivity, no-match, absent-config-equals-default), drop filter (VO drop, path-prefix drop, passthrough, empty-config-drops-nothing), drop-wins precedence, and end-to-end pipeline drop |
| `cmd/collector/main.go` | `buildCorrelatorConfig` passes WLCG and filter config through |
| `config/config-collector.yaml` | Both new blocks documented (commented out, showing defaults) |

## Field names confirmed from source

- VO field: `CollectorRecord.VO` (JSON `"vo,omitempty"`)
- Path field: `CollectorRecord.Filename` (JSON `"filename"`)

## How defaults are wired

Viper `SetDefault` is called for `wlcg.vos` and `wlcg.path_prefixes` before the `GetStringSlice` reads, so an empty/absent config file yields `["cms"]` and `["/store", "/user/dteam"]` respectively. The `Correlator` also applies the same defaults in `NewCorrelatorWithConfig` if the slices passed through `CorrelatorConfig` are empty, covering callers that construct a correlator directly (e.g. tests).

For the drop filter there is no `SetDefault` — an absent key returns an empty slice from viper, and empty slices mean "drop nothing", which is correct.

## New metric

```
shoveler_records_dropped_total{reason="vo"}
shoveler_records_dropped_total{reason="path_prefix"}
```

## Test plan

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — all packages pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01W59s3EXdnACWi6YVxFudFr)_