### PR TITLE
feat(collector): add per-server / per-stream / per-record-type metrics

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -137,6 +137,13 @@ func emitEnrichedRecord(msg collector.EnrichedRecord, output connectors.OutputCo
 // publishEnrichedRecord handles the complete publish flow for a pipeline result (metrics + output)
 func publishEnrichedRecord(msg collector.EnrichedRecord, output connectors.OutputConnector, logger *logrus.Logger) {
 	shoveler.RecordsEmitted.Inc()
+	if msg.Record != nil {
+		serverIP := msg.Record.ServerIP
+		if serverIP == "" {
+			serverIP = "unknown"
+		}
+		shoveler.RecordsEmittedByServer.WithLabelValues(serverIP).Inc()
+	}
 
 	// Calculate latency if we have timing info
 	if msg.Record != nil && msg.Record.StartTime > 0 && msg.Record.EndTime > 0 {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -366,6 +366,43 @@ func handleParsedPacket(packet *parser.Packet, correlator *collector.Correlator,
 	}
 }
 
+// packetTypeLabel returns the shoveler_packets_by_type label value for a parsed packet.
+// XML summary packets (byte '<') are labelled "xml". All other types use the human-readable
+// name that corresponds to the XRootD frame code byte stored in packet.PacketType.
+func packetTypeLabel(packet *parser.Packet) string {
+	if packet.IsXML {
+		return "xml"
+	}
+	switch packet.PacketType {
+	case parser.PacketTypeFStat:
+		return "fstat"
+	case parser.PacketTypeDictID:
+		return "dict"
+	case parser.PacketTypeUser:
+		return "user"
+	case parser.PacketTypeEAInfo:
+		return "eainfo"
+	case parser.PacketTypeMap:
+		return "map"
+	case parser.PacketTypeGStream:
+		return "gstream"
+	case parser.PacketTypeInfo:
+		return "info"
+	case parser.PacketTypeTrace:
+		return "trace"
+	case parser.PacketTypeToken:
+		return "token"
+	case parser.PacketTypePurg:
+		return "purge"
+	case parser.PacketTypeRedir:
+		return "redir"
+	case parser.PacketTypeXFR:
+		return "xfr"
+	default:
+		return "unknown"
+	}
+}
+
 // processPackets is the common packet processing loop for all input types
 func processPackets(source input.PacketSource, correlator *collector.Correlator, gstreamPackets chan *parser.Packet, gstreamDropCount *int64, enrichmentDestination collector.EnrichmentDestination, logger *logrus.Logger) {
 	for pktWithAddr := range source.PacketsWithAddr() {
@@ -383,6 +420,9 @@ func processPackets(source input.PacketSource, correlator *collector.Correlator,
 			continue
 		}
 		shoveler.PacketsParsedOK.Inc()
+		if packet != nil {
+			shoveler.PacketsByType.WithLabelValues(packetTypeLabel(packet)).Inc()
+		}
 
 		// Set remote address for server ID calculation
 		if packet != nil {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -367,40 +367,13 @@ func handleParsedPacket(packet *parser.Packet, correlator *collector.Correlator,
 }
 
 // packetTypeLabel returns the shoveler_packets_by_type label value for a parsed packet.
-// XML summary packets (byte '<') are labelled "xml". All other types use the human-readable
-// name that corresponds to the XRootD frame code byte stored in packet.PacketType.
+// XML summary packets (byte '<') are labelled "xml". All other types use
+// collector.PacketTypeName for the label.
 func packetTypeLabel(packet *parser.Packet) string {
 	if packet.IsXML {
 		return "xml"
 	}
-	switch packet.PacketType {
-	case parser.PacketTypeFStat:
-		return "fstat"
-	case parser.PacketTypeDictID:
-		return "dict"
-	case parser.PacketTypeUser:
-		return "user"
-	case parser.PacketTypeEAInfo:
-		return "eainfo"
-	case parser.PacketTypeMap:
-		return "map"
-	case parser.PacketTypeGStream:
-		return "gstream"
-	case parser.PacketTypeInfo:
-		return "info"
-	case parser.PacketTypeTrace:
-		return "trace"
-	case parser.PacketTypeToken:
-		return "token"
-	case parser.PacketTypePurg:
-		return "purge"
-	case parser.PacketTypeRedir:
-		return "redir"
-	case parser.PacketTypeXFR:
-		return "xfr"
-	default:
-		return "unknown"
-	}
+	return collector.PacketTypeName(packet.PacketType)
 }
 
 // processPackets is the common packet processing loop for all input types

--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -312,6 +312,7 @@ func (c *Correlator) ProcessPacket(packet *parser.Packet) ([]*CollectorRecord, e
 	for _, rec := range packet.FileRecords {
 		switch r := rec.(type) {
 		case parser.FileOpenRecord:
+			fstreamFileOpenRecordsTotal.WithLabelValues(serverIP).Inc()
 			result, err := c.handleFileOpen(r, packet, serverID)
 			if err != nil {
 				return records, err
@@ -320,6 +321,7 @@ func (c *Correlator) ProcessPacket(packet *parser.Packet) ([]*CollectorRecord, e
 				records = append(records, result)
 			}
 		case parser.FileCloseRecord:
+			fstreamFileCloseRecordsTotal.WithLabelValues(serverIP).Inc()
 			result, err := c.handleFileClose(r, packet, serverID)
 			if err != nil {
 				return records, err
@@ -328,6 +330,7 @@ func (c *Correlator) ProcessPacket(packet *parser.Packet) ([]*CollectorRecord, e
 				records = append(records, result)
 			}
 		case parser.FileTimeRecord:
+			fstreamFileTimeRecordsTotal.WithLabelValues(serverIP).Inc()
 			result, err := c.handleTimeRecord(r, packet, serverID)
 			if err != nil {
 				return records, err

--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -312,7 +312,7 @@ func (c *Correlator) ProcessPacket(packet *parser.Packet) ([]*CollectorRecord, e
 	for _, rec := range packet.FileRecords {
 		switch r := rec.(type) {
 		case parser.FileOpenRecord:
-			fstreamFileOpenRecordsTotal.WithLabelValues(serverIP).Inc()
+			fileOpenRecordsTotal.WithLabelValues(serverIP).Inc()
 			result, err := c.handleFileOpen(r, packet, serverID)
 			if err != nil {
 				return records, err
@@ -321,7 +321,7 @@ func (c *Correlator) ProcessPacket(packet *parser.Packet) ([]*CollectorRecord, e
 				records = append(records, result)
 			}
 		case parser.FileCloseRecord:
-			fstreamFileCloseRecordsTotal.WithLabelValues(serverIP).Inc()
+			fileCloseRecordsTotal.WithLabelValues(serverIP).Inc()
 			result, err := c.handleFileClose(r, packet, serverID)
 			if err != nil {
 				return records, err
@@ -330,7 +330,7 @@ func (c *Correlator) ProcessPacket(packet *parser.Packet) ([]*CollectorRecord, e
 				records = append(records, result)
 			}
 		case parser.FileTimeRecord:
-			fstreamFileTimeRecordsTotal.WithLabelValues(serverIP).Inc()
+			fileTimeRecordsTotal.WithLabelValues(serverIP).Inc()
 			result, err := c.handleTimeRecord(r, packet, serverID)
 			if err != nil {
 				return records, err

--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -243,6 +243,38 @@ func NewCorrelatorWithConfig(config CorrelatorConfig) *Correlator {
 	return c
 }
 
+// PacketTypeName maps an XRootD packet-type byte to a readable label.
+func PacketTypeName(code byte) string {
+	switch code {
+	case parser.PacketTypeMap:
+		return "map"
+	case parser.PacketTypeDictID:
+		return "dict"
+	case parser.PacketTypeFStat:
+		return "fstat"
+	case parser.PacketTypeGStream:
+		return "gstream"
+	case parser.PacketTypeInfo:
+		return "info"
+	case parser.PacketTypePurg:
+		return "purg"
+	case parser.PacketTypeRedir:
+		return "redir"
+	case parser.PacketTypeTrace:
+		return "trace"
+	case parser.PacketTypeToken:
+		return "token"
+	case parser.PacketTypeUser:
+		return "user"
+	case parser.PacketTypeEAInfo:
+		return "eainfo"
+	case parser.PacketTypeXFR:
+		return "xfr"
+	default:
+		return "unknown"
+	}
+}
+
 // ProcessPacket processes a packet and returns records for all correlated file operations
 // Returns a slice of records since a packet can contain multiple file close events that each emit a record
 func (c *Correlator) ProcessPacket(packet *parser.Packet) ([]*CollectorRecord, error) {
@@ -250,6 +282,9 @@ func (c *Correlator) ProcessPacket(packet *parser.Packet) ([]*CollectorRecord, e
 		// XML packets are not correlated
 		return nil, nil
 	}
+
+	serverIP := extractIPFromHost(extractHostFromRemoteAddr(packet.RemoteAddr))
+	packetsPerServerTotal.WithLabelValues(serverIP, PacketTypeName(packet.PacketType)).Inc()
 
 	// Calculate server ID: serverStart#addr#port
 	serverID := c.getServerID(packet)
@@ -319,6 +354,9 @@ func (c *Correlator) ProcessGStreamPacket(packet *parser.Packet) ([]map[string]i
 	if packet.GStreamRecord == nil {
 		return nil, 0, nil
 	}
+
+	serverIP := extractIPFromHost(extractHostFromRemoteAddr(packet.RemoteAddr))
+	packetsPerServerTotal.WithLabelValues(serverIP, "gstream").Inc()
 
 	gstream := packet.GStreamRecord
 	serverID := c.getServerID(packet)

--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -257,7 +257,7 @@ func PacketTypeName(code byte) string {
 	case parser.PacketTypeInfo:
 		return "info"
 	case parser.PacketTypePurg:
-		return "purg"
+		return "purge"
 	case parser.PacketTypeRedir:
 		return "redir"
 	case parser.PacketTypeTrace:

--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -785,6 +785,7 @@ func (c *Correlator) handleFileClose(rec parser.FileCloseRecord, packet *parser.
 	val, exists := c.stateMap.Get(key)
 	if !exists {
 		c.logger.Debugf("No open record found for file close: serverID=%s, fileID=%d - creating standalone record", serverID, rec.Header.FileId)
+		standaloneCloseRecordsTotal.Inc()
 		// No open record found, create a standalone close record
 		return c.createStandaloneCloseRecord(rec, packet), nil
 	}

--- a/collector/correlator_test.go
+++ b/collector/correlator_test.go
@@ -1302,3 +1302,32 @@ func TestExtractHostFromRemoteAddr_UnbracketedIPv6WithShortPort(t *testing.T) {
 	// so parser should preserve it as-is rather than truncate.
 	assert.Equal(t, addr, extractHostFromRemoteAddr(addr))
 }
+
+// TestPacketTypeName verifies that XRootD monitoring packet types are correctly mapped
+// to their corresponding string representations, including the fallback for unknown types.
+// It helps in finding missed case or typos, as the labels are hardcoded.
+func TestPacketTypeName(t *testing.T) {
+	tests := []struct {
+		code     byte
+		expected string
+	}{
+		{parser.PacketTypeMap, "map"},
+		{parser.PacketTypeDictID, "dict"},
+		{parser.PacketTypeFStat, "fstat"},
+		{parser.PacketTypeGStream, "gstream"},
+		{parser.PacketTypeInfo, "info"},
+		{parser.PacketTypePurg, "purge"},
+		{parser.PacketTypeRedir, "redir"},
+		{parser.PacketTypeTrace, "trace"},
+		{parser.PacketTypeToken, "token"},
+		{parser.PacketTypeUser, "user"},
+		{parser.PacketTypeEAInfo, "eainfo"},
+		{parser.PacketTypeXFR, "xfr"},
+		{0xFF, "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, PacketTypeName(tt.code))
+		})
+	}
+}

--- a/collector/correlator_test.go
+++ b/collector/correlator_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/opensciencegrid/xrootd-monitoring-shoveler/parser"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1301,6 +1302,81 @@ func TestExtractHostFromRemoteAddr_UnbracketedIPv6WithShortPort(t *testing.T) {
 	// Ambiguous case: full string is also a syntactically valid IPv6 literal,
 	// so parser should preserve it as-is rather than truncate.
 	assert.Equal(t, addr, extractHostFromRemoteAddr(addr))
+}
+
+// TestStandaloneCloseRecordsTotal verifies that the shoveler_standalone_close_records_total
+// counter increments exactly once for each file close that has no matching open in stateMap.
+func TestStandaloneCloseRecordsTotal(t *testing.T) {
+	correlator := NewCorrelator(5*time.Second, 0, nil)
+	defer correlator.Stop()
+
+	before := testutil.ToFloat64(standaloneCloseRecordsTotal)
+
+	closeRec := parser.FileCloseRecord{
+		Header: parser.FileHeader{
+			RecType: parser.RecTypeClose,
+			FileId:  42,
+			UserId:  7,
+		},
+		Xfr: parser.StatXFR{Read: 512},
+	}
+	closePacket := &parser.Packet{
+		Header:      parser.Header{Code: parser.PacketTypeFStat, ServerStart: 9000},
+		FileRecords: []interface{}{closeRec},
+	}
+
+	recs, err := correlator.ProcessPacket(closePacket)
+	require.NoError(t, err)
+	require.Len(t, recs, 1, "standalone close should still produce a record")
+	assert.Equal(t, "unknown", recs[0].Filename, "standalone close should have unknown filename")
+
+	after := testutil.ToFloat64(standaloneCloseRecordsTotal)
+	assert.Equal(t, float64(1), after-before, "counter should increment by 1 for each unmatched close")
+
+	// A second unmatched close for the same fileID should increment again.
+	recs, err = correlator.ProcessPacket(closePacket)
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+
+	assert.Equal(t, float64(2), testutil.ToFloat64(standaloneCloseRecordsTotal)-before,
+		"counter should reflect all unmatched closes, not just the first")
+}
+
+// TestStandaloneCloseCounterNotIncrementedOnCorrelatedClose verifies that a
+// file close that successfully correlates with an open does NOT increment the counter.
+func TestStandaloneCloseCounterNotIncrementedOnCorrelatedClose(t *testing.T) {
+	correlator := NewCorrelator(5*time.Second, 0, nil)
+	defer correlator.Stop()
+
+	before := testutil.ToFloat64(standaloneCloseRecordsTotal)
+
+	openRec := parser.FileOpenRecord{
+		Header:   parser.FileHeader{RecType: parser.RecTypeOpen, FileId: 55, UserId: 1},
+		FileSize: 2048,
+		Lfn:      []byte("/data/correlated.root"),
+	}
+	openPacket := &parser.Packet{
+		Header:      parser.Header{ServerStart: 5000},
+		FileRecords: []interface{}{openRec},
+	}
+	_, err := correlator.ProcessPacket(openPacket)
+	require.NoError(t, err)
+
+	closeRec := parser.FileCloseRecord{
+		Header: parser.FileHeader{RecType: parser.RecTypeClose, FileId: 55, UserId: 1},
+		Xfr:    parser.StatXFR{Read: 1024},
+	}
+	closePacket := &parser.Packet{
+		Header:      parser.Header{ServerStart: 5000},
+		FileRecords: []interface{}{closeRec},
+	}
+	recs, err := correlator.ProcessPacket(closePacket)
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "/data/correlated.root", recs[0].Filename, "correlated close should have correct filename")
+
+	assert.Equal(t, before, testutil.ToFloat64(standaloneCloseRecordsTotal),
+		"correlated close must not increment the standalone counter")
 }
 
 // TestPacketTypeName verifies that XRootD monitoring packet types are correctly mapped

--- a/collector/correlator_test.go
+++ b/collector/correlator_test.go
@@ -1386,7 +1386,7 @@ func TestFStreamFileOpenRecordsTotal(t *testing.T) {
 	defer correlator.Stop()
 
 	serverIP := "127.0.0.1"
-	before := testutil.ToFloat64(fstreamFileOpenRecordsTotal.WithLabelValues(serverIP))
+	before := testutil.ToFloat64(fileOpenRecordsTotal.WithLabelValues(serverIP))
 
 	openRec := parser.FileOpenRecord{
 		Header:   parser.FileHeader{RecType: parser.RecTypeOpen, FileId: 10, UserId: 1},
@@ -1403,7 +1403,7 @@ func TestFStreamFileOpenRecordsTotal(t *testing.T) {
 	_, err := correlator.ProcessPacket(packet)
 	require.NoError(t, err)
 
-	after := testutil.ToFloat64(fstreamFileOpenRecordsTotal.WithLabelValues(serverIP))
+	after := testutil.ToFloat64(fileOpenRecordsTotal.WithLabelValues(serverIP))
 	assert.Equal(t, float64(1), after-before, "counter should increment by 1 per file open record")
 }
 
@@ -1414,7 +1414,7 @@ func TestFStreamFileCloseRecordsTotal(t *testing.T) {
 	defer correlator.Stop()
 
 	serverIP := "127.0.0.2"
-	before := testutil.ToFloat64(fstreamFileCloseRecordsTotal.WithLabelValues(serverIP))
+	before := testutil.ToFloat64(fileCloseRecordsTotal.WithLabelValues(serverIP))
 
 	closeRec := parser.FileCloseRecord{
 		Header: parser.FileHeader{RecType: parser.RecTypeClose, FileId: 20, UserId: 1},
@@ -1430,7 +1430,7 @@ func TestFStreamFileCloseRecordsTotal(t *testing.T) {
 	_, err := correlator.ProcessPacket(packet)
 	require.NoError(t, err)
 
-	after := testutil.ToFloat64(fstreamFileCloseRecordsTotal.WithLabelValues(serverIP))
+	after := testutil.ToFloat64(fileCloseRecordsTotal.WithLabelValues(serverIP))
 	assert.Equal(t, float64(1), after-before, "counter should increment by 1 per file close record")
 }
 
@@ -1441,7 +1441,7 @@ func TestFStreamFileTimeRecordsTotal(t *testing.T) {
 	defer correlator.Stop()
 
 	serverIP := "127.0.0.3"
-	before := testutil.ToFloat64(fstreamFileTimeRecordsTotal.WithLabelValues(serverIP))
+	before := testutil.ToFloat64(fileTimeRecordsTotal.WithLabelValues(serverIP))
 
 	timeRec := parser.FileTimeRecord{
 		Header: parser.FileHeader{RecType: parser.RecTypeTime, FileId: 30},
@@ -1459,7 +1459,7 @@ func TestFStreamFileTimeRecordsTotal(t *testing.T) {
 	_, err := correlator.ProcessPacket(packet)
 	require.NoError(t, err)
 
-	after := testutil.ToFloat64(fstreamFileTimeRecordsTotal.WithLabelValues(serverIP))
+	after := testutil.ToFloat64(fileTimeRecordsTotal.WithLabelValues(serverIP))
 	assert.Equal(t, float64(1), after-before, "counter should increment by 1 per file time record")
 }
 
@@ -1470,9 +1470,9 @@ func TestFStreamMixedRecordsCountedIndependently(t *testing.T) {
 	defer correlator.Stop()
 
 	serverIP := "127.0.0.4"
-	beforeOpen := testutil.ToFloat64(fstreamFileOpenRecordsTotal.WithLabelValues(serverIP))
-	beforeClose := testutil.ToFloat64(fstreamFileCloseRecordsTotal.WithLabelValues(serverIP))
-	beforeTime := testutil.ToFloat64(fstreamFileTimeRecordsTotal.WithLabelValues(serverIP))
+	beforeOpen := testutil.ToFloat64(fileOpenRecordsTotal.WithLabelValues(serverIP))
+	beforeClose := testutil.ToFloat64(fileCloseRecordsTotal.WithLabelValues(serverIP))
+	beforeTime := testutil.ToFloat64(fileTimeRecordsTotal.WithLabelValues(serverIP))
 
 	openRec := parser.FileOpenRecord{
 		Header: parser.FileHeader{RecType: parser.RecTypeOpen, FileId: 50, UserId: 1},
@@ -1498,9 +1498,9 @@ func TestFStreamMixedRecordsCountedIndependently(t *testing.T) {
 	_, err := correlator.ProcessPacket(packet)
 	require.NoError(t, err)
 
-	assert.Equal(t, float64(1), testutil.ToFloat64(fstreamFileOpenRecordsTotal.WithLabelValues(serverIP))-beforeOpen)
-	assert.Equal(t, float64(1), testutil.ToFloat64(fstreamFileCloseRecordsTotal.WithLabelValues(serverIP))-beforeClose)
-	assert.Equal(t, float64(1), testutil.ToFloat64(fstreamFileTimeRecordsTotal.WithLabelValues(serverIP))-beforeTime)
+	assert.Equal(t, float64(1), testutil.ToFloat64(fileOpenRecordsTotal.WithLabelValues(serverIP))-beforeOpen)
+	assert.Equal(t, float64(1), testutil.ToFloat64(fileCloseRecordsTotal.WithLabelValues(serverIP))-beforeClose)
+	assert.Equal(t, float64(1), testutil.ToFloat64(fileTimeRecordsTotal.WithLabelValues(serverIP))-beforeTime)
 }
 
 // TestPacketTypeName verifies that XRootD monitoring packet types are correctly mapped

--- a/collector/correlator_test.go
+++ b/collector/correlator_test.go
@@ -1379,6 +1379,130 @@ func TestStandaloneCloseCounterNotIncrementedOnCorrelatedClose(t *testing.T) {
 		"correlated close must not increment the standalone counter")
 }
 
+// TestFStreamFileOpenRecordsTotal verifies the fstream_file_open_records_total counter
+// increments once per FileOpen record seen in a packet's FileRecords.
+func TestFStreamFileOpenRecordsTotal(t *testing.T) {
+	correlator := NewCorrelator(5*time.Second, 0, nil)
+	defer correlator.Stop()
+
+	serverIP := "127.0.0.1"
+	before := testutil.ToFloat64(fstreamFileOpenRecordsTotal.WithLabelValues(serverIP))
+
+	openRec := parser.FileOpenRecord{
+		Header:   parser.FileHeader{RecType: parser.RecTypeOpen, FileId: 10, UserId: 1},
+		FileSize: 1024,
+		Lfn:      []byte("/data/file.root"),
+	}
+	packet := &parser.Packet{
+		Header:      parser.Header{Code: parser.PacketTypeFStat, ServerStart: 1000},
+		PacketType:  parser.PacketTypeFStat,
+		FileRecords: []interface{}{openRec},
+		RemoteAddr:  serverIP + ":1094",
+	}
+
+	_, err := correlator.ProcessPacket(packet)
+	require.NoError(t, err)
+
+	after := testutil.ToFloat64(fstreamFileOpenRecordsTotal.WithLabelValues(serverIP))
+	assert.Equal(t, float64(1), after-before, "counter should increment by 1 per file open record")
+}
+
+// TestFStreamFileCloseRecordsTotal verifies the fstream_file_close_records_total counter
+// increments once per FileClose record seen in a packet's FileRecords.
+func TestFStreamFileCloseRecordsTotal(t *testing.T) {
+	correlator := NewCorrelator(5*time.Second, 0, nil)
+	defer correlator.Stop()
+
+	serverIP := "127.0.0.2"
+	before := testutil.ToFloat64(fstreamFileCloseRecordsTotal.WithLabelValues(serverIP))
+
+	closeRec := parser.FileCloseRecord{
+		Header: parser.FileHeader{RecType: parser.RecTypeClose, FileId: 20, UserId: 1},
+		Xfr:    parser.StatXFR{Read: 512},
+	}
+	packet := &parser.Packet{
+		Header:      parser.Header{Code: parser.PacketTypeFStat, ServerStart: 2000},
+		PacketType:  parser.PacketTypeFStat,
+		FileRecords: []interface{}{closeRec},
+		RemoteAddr:  serverIP + ":1094",
+	}
+
+	_, err := correlator.ProcessPacket(packet)
+	require.NoError(t, err)
+
+	after := testutil.ToFloat64(fstreamFileCloseRecordsTotal.WithLabelValues(serverIP))
+	assert.Equal(t, float64(1), after-before, "counter should increment by 1 per file close record")
+}
+
+// TestFStreamFileTimeRecordsTotal verifies the fstream_file_time_records_total counter
+// increments once per FileTime (TOD) record seen in a packet's FileRecords.
+func TestFStreamFileTimeRecordsTotal(t *testing.T) {
+	correlator := NewCorrelator(5*time.Second, 0, nil)
+	defer correlator.Stop()
+
+	serverIP := "127.0.0.3"
+	before := testutil.ToFloat64(fstreamFileTimeRecordsTotal.WithLabelValues(serverIP))
+
+	timeRec := parser.FileTimeRecord{
+		Header: parser.FileHeader{RecType: parser.RecTypeTime, FileId: 30},
+		TBeg:   3000,
+		TEnd:   4000,
+		SID:    99,
+	}
+	packet := &parser.Packet{
+		Header:      parser.Header{Code: parser.PacketTypeFStat, ServerStart: 3000},
+		PacketType:  parser.PacketTypeFStat,
+		FileRecords: []interface{}{timeRec},
+		RemoteAddr:  serverIP + ":1094",
+	}
+
+	_, err := correlator.ProcessPacket(packet)
+	require.NoError(t, err)
+
+	after := testutil.ToFloat64(fstreamFileTimeRecordsTotal.WithLabelValues(serverIP))
+	assert.Equal(t, float64(1), after-before, "counter should increment by 1 per file time record")
+}
+
+// TestFStreamMixedRecordsCountedIndependently verifies that a packet containing
+// multiple record types increments each counter independently.
+func TestFStreamMixedRecordsCountedIndependently(t *testing.T) {
+	correlator := NewCorrelator(5*time.Second, 0, nil)
+	defer correlator.Stop()
+
+	serverIP := "127.0.0.4"
+	beforeOpen := testutil.ToFloat64(fstreamFileOpenRecordsTotal.WithLabelValues(serverIP))
+	beforeClose := testutil.ToFloat64(fstreamFileCloseRecordsTotal.WithLabelValues(serverIP))
+	beforeTime := testutil.ToFloat64(fstreamFileTimeRecordsTotal.WithLabelValues(serverIP))
+
+	openRec := parser.FileOpenRecord{
+		Header: parser.FileHeader{RecType: parser.RecTypeOpen, FileId: 50, UserId: 1},
+		Lfn:    []byte("/data/mixed.root"),
+	}
+	timeRec := parser.FileTimeRecord{
+		Header: parser.FileHeader{RecType: parser.RecTypeTime, FileId: 51},
+		TBeg:   5000,
+		TEnd:   6000,
+		SID:    77,
+	}
+	closeRec := parser.FileCloseRecord{
+		Header: parser.FileHeader{RecType: parser.RecTypeClose, FileId: 52},
+		Xfr:    parser.StatXFR{Read: 256},
+	}
+	packet := &parser.Packet{
+		Header:      parser.Header{Code: parser.PacketTypeFStat, ServerStart: 5000},
+		PacketType:  parser.PacketTypeFStat,
+		FileRecords: []interface{}{openRec, timeRec, closeRec},
+		RemoteAddr:  serverIP + ":1094",
+	}
+
+	_, err := correlator.ProcessPacket(packet)
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(fstreamFileOpenRecordsTotal.WithLabelValues(serverIP))-beforeOpen)
+	assert.Equal(t, float64(1), testutil.ToFloat64(fstreamFileCloseRecordsTotal.WithLabelValues(serverIP))-beforeClose)
+	assert.Equal(t, float64(1), testutil.ToFloat64(fstreamFileTimeRecordsTotal.WithLabelValues(serverIP))-beforeTime)
+}
+
 // TestPacketTypeName verifies that XRootD monitoring packet types are correctly mapped
 // to their corresponding string representations, including the fallback for unknown types.
 // It helps in finding missed case or typos, as the labels are hardcoded.

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -37,24 +37,25 @@ var (
 		Help: "Total number of file close records emitted without a matching open in stateMap (degraded records missing LFN, open-time, and full user context)",
 	})
 
-	// fstreamFileOpenRecordsTotal counts FileOpen records parsed from f-stream packets,
-	// broken down by upstream server IP. Each f-stream packet can carry multiple records.
-	fstreamFileOpenRecordsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "shoveler_fstream_file_open_records_total",
-		Help: "Total number of file open records received in f-stream packets per upstream server IP",
+	// fileOpenRecordsTotal counts FileOpen records parsed from file-record packets
+	// (both f-stream/fstat and t-stream/trace), broken down by upstream server IP.
+	// Each packet can carry multiple records.
+	fileOpenRecordsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "shoveler_file_open_records_total",
+		Help: "Total number of file open records received in f-stream and t-stream packets per upstream server IP",
 	}, []string{"server_ip"})
 
-	// fstreamFileCloseRecordsTotal counts FileClose records parsed from f-stream packets,
-	// broken down by upstream server IP.
-	fstreamFileCloseRecordsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "shoveler_fstream_file_close_records_total",
-		Help: "Total number of file close records received in f-stream packets per upstream server IP",
+	// fileCloseRecordsTotal counts FileClose records parsed from file-record packets
+	// (both f-stream/fstat and t-stream/trace), broken down by upstream server IP.
+	fileCloseRecordsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "shoveler_file_close_records_total",
+		Help: "Total number of file close records received in f-stream and t-stream packets per upstream server IP",
 	}, []string{"server_ip"})
 
-	// fstreamFileTimeRecordsTotal counts FileTime (TOD) records parsed from f-stream packets,
-	// broken down by upstream server IP.
-	fstreamFileTimeRecordsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "shoveler_fstream_file_time_records_total",
-		Help: "Total number of file time (TOD) records received in f-stream packets per upstream server IP",
+	// fileTimeRecordsTotal counts FileTime (TOD) records parsed from file-record packets
+	// (both f-stream/fstat and t-stream/trace), broken down by upstream server IP.
+	fileTimeRecordsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "shoveler_file_time_records_total",
+		Help: "Total number of file time (TOD) records received in f-stream and t-stream packets per upstream server IP",
 	}, []string{"server_ip"})
 )

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -26,4 +26,14 @@ var (
 		Name: "shoveler_packets_by_server_total",
 		Help: "Total number of successfully parsed monitoring packets per upstream server IP and XRootD stream type",
 	}, []string{"server_ip", "packet_type"})
+
+	// standaloneCloseRecordsTotal counts file close records for which no matching
+	// open was found in stateMap. These records are emitted via createStandaloneCloseRecord
+	// and are degraded: they lack LFN, open-time, and full user context. A sustained
+	// rise here indicates the correlator is missing opens (e.g. due to packet loss,
+	// TTL expiry, or shoveler restart mid-session).
+	standaloneCloseRecordsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "shoveler_standalone_close_records_total",
+		Help: "Total number of file close records emitted without a matching open in stateMap (degraded records missing LFN, open-time, and full user context)",
+	})
 )

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -17,4 +17,13 @@ var (
 		Name: "shoveler_enrichment_queue_size",
 		Help: "Current number of pending records in the enrichment queue",
 	})
+
+	// packetsPerServerTotal counts successfully parsed monitoring packets broken
+	// down by the upstream server IP and the XRootD stream / frame type.  Use
+	// this to verify that each XRootD node is still sending and to see which
+	// streams (fstat, dict, user, eainfo, map, gstream, …) are active.
+	packetsPerServerTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "shoveler_packets_by_server_total",
+		Help: "Total number of successfully parsed monitoring packets per upstream server IP and XRootD stream type",
+	}, []string{"server_ip", "packet_type"})
 )

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -36,4 +36,25 @@ var (
 		Name: "shoveler_standalone_close_records_total",
 		Help: "Total number of file close records emitted without a matching open in stateMap (degraded records missing LFN, open-time, and full user context)",
 	})
+
+	// fstreamFileOpenRecordsTotal counts FileOpen records parsed from f-stream packets,
+	// broken down by upstream server IP. Each f-stream packet can carry multiple records.
+	fstreamFileOpenRecordsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "shoveler_fstream_file_open_records_total",
+		Help: "Total number of file open records received in f-stream packets per upstream server IP",
+	}, []string{"server_ip"})
+
+	// fstreamFileCloseRecordsTotal counts FileClose records parsed from f-stream packets,
+	// broken down by upstream server IP.
+	fstreamFileCloseRecordsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "shoveler_fstream_file_close_records_total",
+		Help: "Total number of file close records received in f-stream packets per upstream server IP",
+	}, []string{"server_ip"})
+
+	// fstreamFileTimeRecordsTotal counts FileTime (TOD) records parsed from f-stream packets,
+	// broken down by upstream server IP.
+	fstreamFileTimeRecordsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "shoveler_fstream_file_time_records_total",
+		Help: "Total number of file time (TOD) records received in f-stream packets per upstream server IP",
+	}, []string{"server_ip"})
 )

--- a/metrics.go
+++ b/metrics.go
@@ -87,6 +87,18 @@ var (
 		Name: "shoveler_gstream_queue_size",
 		Help: "Current number of pending gstream packets in the async worker queue",
 	})
+
+	// PacketsByType counts successfully parsed packets broken down by XRootD frame type.
+	// Label values: "fstat" (f), "dict" (d), "user" (u), "eainfo" (U), "map" (=),
+	// "gstream" (g), "info" (i), "trace" (t), "token" (T), "purge" (p), "redir" (r),
+	// "xfr" (x), and "xml" (XML summary packets).
+	// Use this alongside shoveler_records_emitted: when records_emitted is low relative
+	// to packets_received but "fstat" counts are also low, the traffic is dominated by
+	// context packets (dict/user/eainfo/map) rather than missing close events.
+	PacketsByType = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "shoveler_packets_by_type",
+		Help: "Total number of successfully parsed packets, partitioned by XRootD packet type",
+	}, []string{"packet_type"})
 )
 
 func StartMetrics(metricsPort int) {

--- a/metrics.go
+++ b/metrics.go
@@ -61,6 +61,13 @@ var (
 		Help: "The total number of collector records emitted",
 	})
 
+	// RecordsEmittedByServer counts correlated file-access records published per upstream
+	// server IP.
+	RecordsEmittedByServer = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "shoveler_records_emitted_by_server_total",
+		Help: "Total number of collector records emitted, partitioned by upstream server IP",
+	}, []string{"server_ip"})
+
 	ParseTimeMs = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "shoveler_parse_time_ms",
 		Help:    "Packet parsing time in milliseconds",


### PR DESCRIPTION
Fixes #96

Adds a set of Prometheus counters to the collector for better ingest/emit observability:

- `shoveler_packets_by_type` - parsed packets by XRootD packet type
- `shoveler_packets_by_server_total` - parsed packets per upstream server IP + stream type
- `shoveler_records_emitted_by_server_total` - records emitted per upstream server IP
- `shoveler_standalone_close_records_total`- file closes emitted with no matching open in the state map
- `shoveler_file_open_records_total` / `shoveler_file_close_records_total` / `shoveler_file_time_records_total` - f stream/t-stream record types per server IP

### Notes

- Includes unit tests (`collector/correlator_test.go`)
- Label sets are bounded (server IP + fixed stream/type enums)
- `f-stream`/`t-stream` open-record counter was renamed to `fileOpenRecords` since both streams contribute to it