### PR TITLE
feat(collector): configurable WLCG producer/type metadata

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -235,7 +235,7 @@ func emitGStreamEvent(event map[string]interface{}, streamType byte, config *sho
 	var eventJSON []byte
 	var err error
 	if needsWLCG {
-		wlcgEvent, convErr := collector.ConvertGStreamToWLCG(event, streamType == 'P')
+		wlcgEvent, convErr := collector.ConvertGStreamToWLCG(event, streamType == 'P', buildWLCGMetadata(config))
 		if convErr != nil {
 			logger.Errorln("Failed to convert gstream event to WLCG:", convErr)
 			return
@@ -256,6 +256,16 @@ func emitGStreamEvent(event map[string]interface{}, streamType byte, config *sho
 	}
 }
 
+// buildWLCGMetadata maps the WLCG producer/type config into the collector's
+// metadata struct used when creating WLCG-formatted records.
+func buildWLCGMetadata(config *shoveler.Config) collector.WLCGMetadata {
+	return collector.WLCGMetadata{
+		Producer:        config.WLCG.Producer,
+		Type:            config.WLCG.Type,
+		GStreamProducer: config.WLCG.GStreamProducer,
+	}
+}
+
 // buildCorrelatorConfig creates a correlator config from the main config
 func buildCorrelatorConfig(config *shoveler.Config, logger *logrus.Logger) collector.CorrelatorConfig {
 	ttl := time.Duration(config.State.EntryTTL) * time.Second
@@ -268,6 +278,7 @@ func buildCorrelatorConfig(config *shoveler.Config, logger *logrus.Logger) colle
 		DNSTimeout:          time.Duration(config.State.DNSTimeout) * time.Second,
 		EnrichmentWorkers:   config.State.EnrichmentWorkers,
 		EnrichmentQueueSize: config.State.EnrichmentQueueSize,
+		WLCGMetadata:        buildWLCGMetadata(config),
 		Logger:              logger,
 		WLCGVOs:             config.WLCG.VOs,
 		WLCGPathPrefixes:    config.WLCG.PathPrefixes,

--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -136,6 +136,7 @@ type Correlator struct {
 	enrichers             []RecordEnricher
 	enrichmentWG          sync.WaitGroup
 	enrichmentDropCount   int64 // atomic; counts records dropped due to full queue
+	wlcgMetadata          WLCGMetadata
 	ctx                   context.Context
 	cancel                context.CancelFunc
 
@@ -157,6 +158,7 @@ type CorrelatorConfig struct {
 	DNSTimeout          time.Duration
 	EnrichmentWorkers   int // Number of enrichment worker goroutines (default: 5)
 	EnrichmentQueueSize int // Maximum number of pending enrichment requests (default: 1000000)
+	WLCGMetadata        WLCGMetadata // producer/type values used in WLCG records
 	Logger              *logrus.Logger
 
 	// WLCG routing: records matching any VO (case-insensitive) or path prefix are
@@ -225,6 +227,7 @@ func NewCorrelatorWithConfig(config CorrelatorConfig) *Correlator {
 		dnsResolver:           &defaultDNSResolver{},
 		enrichmentWorkerCount: config.EnrichmentWorkers,
 		enrichmentQueueSize:   config.EnrichmentQueueSize,
+		wlcgMetadata:          config.WLCGMetadata.withDefaults(),
 		ctx:                   ctx,
 		cancel:                cancel,
 		wlcgVOs:               wlcgVOs,

--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -227,7 +227,7 @@ func NewCorrelatorWithConfig(config CorrelatorConfig) *Correlator {
 		dnsResolver:           &defaultDNSResolver{},
 		enrichmentWorkerCount: config.EnrichmentWorkers,
 		enrichmentQueueSize:   config.EnrichmentQueueSize,
-		wlcgMetadata:          config.WLCGMetadata.withDefaults(),
+		wlcgMetadata:          config.WLCGMetadata,
 		ctx:                   ctx,
 		cancel:                cancel,
 		wlcgVOs:               wlcgVOs,

--- a/collector/enrichment.go
+++ b/collector/enrichment.go
@@ -261,7 +261,7 @@ func (c *Correlator) processEnrichmentRequest(req enrichmentRequest) {
 
 func (c *Correlator) buildEnrichedRecord(record *CollectorRecord, wlcgExchange string) (EnrichedRecord, error) {
 	if c.matchesWLCG(record) {
-		wlcgRecord, err := ConvertToWLCG(record)
+		wlcgRecord, err := ConvertToWLCG(record, c.wlcgMetadata)
 		if err != nil {
 			return EnrichedRecord{}, err
 		}

--- a/collector/wlcg_converter.go
+++ b/collector/wlcg_converter.go
@@ -83,48 +83,18 @@ func IsWLCGPacket(record *CollectorRecord) bool {
 // WLCGMetadata holds the configurable producer/type values used to create the
 // metadata block of WLCG-formatted records. They identify the data source to the
 // downstream pipeline and differ between deployments, so they are supplied via
-// configuration rather than hardcoded. Defaults match the values used by the OSG
-// upstream collector (opensciencegrid/xrootd-monitoring-collector).
+// configuration rather than hardcoded. The converter uses these values as-is;
+// the defaults live in the config layer (config.go sets them with viper), so the
+// binary always supplies complete values here.
 type WLCGMetadata struct {
 	Producer        string // metadata.producer for file-transfer (file-close) records
 	Type            string // metadata.type for file-transfer records
 	GStreamProducer string // metadata.producer for gstream cache & TPC records
 }
 
-// DefaultWLCGMetadata returns the producer/type values hardcoded in the OSG
-// upstream collector, used when no override is configured. This is the single
-// source of truth for those defaults: the config layer (config.go) deliberately
-// leaves unset fields empty and relies on withDefaults() to fill them, so the
-// defaults are defined in exactly one place.
-func DefaultWLCGMetadata() WLCGMetadata {
-	return WLCGMetadata{
-		Producer:        "cms",
-		Type:            "aaa-ng",
-		GStreamProducer: "cms-xrootd-cache",
-	}
-}
-
-// withDefaults fills any empty field with its default, so callers may supply
-// partial overrides (or the zero value) without emitting blank metadata.
-func (m WLCGMetadata) withDefaults() WLCGMetadata {
-	d := DefaultWLCGMetadata()
-	if m.Producer == "" {
-		m.Producer = d.Producer
-	}
-	if m.Type == "" {
-		m.Type = d.Type
-	}
-	if m.GStreamProducer == "" {
-		m.GStreamProducer = d.GStreamProducer
-	}
-	return m
-}
-
 // ConvertToWLCG converts a CollectorRecord to WLCG format
 // Based on references/wlcg_converter.py
 func ConvertToWLCG(record *CollectorRecord, meta WLCGMetadata) (*WLCGRecord, error) {
-	meta = meta.withDefaults()
-
 	// Generate unique ID
 	uniqueID := uuid.New().String()
 
@@ -361,8 +331,6 @@ const (
 // ConvertGStreamToWLCG adds WLCG metadata to a gstream event map
 // Based on references/wlcg_converter.py::ConvertGstream
 func ConvertGStreamToWLCG(event map[string]interface{}, isTPC bool, meta WLCGMetadata) (map[string]interface{}, error) {
-	meta = meta.withDefaults()
-
 	eventCopy := make(map[string]interface{})
 	for k, v := range event {
 		eventCopy[k] = v

--- a/collector/wlcg_converter.go
+++ b/collector/wlcg_converter.go
@@ -80,9 +80,48 @@ func IsWLCGPacket(record *CollectorRecord) bool {
 	return matchesWLCGWithRules(record, defaultWLCGVOs, defaultWLCGPathPrefixes)
 }
 
+// WLCGMetadata holds the configurable producer/type values used to create the
+// metadata block of WLCG-formatted records. They identify the data source to the
+// downstream pipeline and differ between deployments, so they are supplied via
+// configuration rather than hardcoded. Defaults match the values used by the OSG
+// upstream collector (opensciencegrid/xrootd-monitoring-collector).
+type WLCGMetadata struct {
+	Producer        string // metadata.producer for file-transfer (file-close) records
+	Type            string // metadata.type for file-transfer records
+	GStreamProducer string // metadata.producer for gstream cache & TPC records
+}
+
+// DefaultWLCGMetadata returns the producer/type values hardcoded in the OSG
+// upstream collector, used when no override is configured.
+func DefaultWLCGMetadata() WLCGMetadata {
+	return WLCGMetadata{
+		Producer:        "cms",
+		Type:            "aaa-ng",
+		GStreamProducer: "cms-xrootd-cache",
+	}
+}
+
+// withDefaults fills any empty field with its default, so callers may supply
+// partial overrides (or the zero value) without emitting blank metadata.
+func (m WLCGMetadata) withDefaults() WLCGMetadata {
+	d := DefaultWLCGMetadata()
+	if m.Producer == "" {
+		m.Producer = d.Producer
+	}
+	if m.Type == "" {
+		m.Type = d.Type
+	}
+	if m.GStreamProducer == "" {
+		m.GStreamProducer = d.GStreamProducer
+	}
+	return m
+}
+
 // ConvertToWLCG converts a CollectorRecord to WLCG format
 // Based on references/wlcg_converter.py
-func ConvertToWLCG(record *CollectorRecord) (*WLCGRecord, error) {
+func ConvertToWLCG(record *CollectorRecord, meta WLCGMetadata) (*WLCGRecord, error) {
+	meta = meta.withDefaults()
+
 	// Generate unique ID
 	uniqueID := uuid.New().String()
 
@@ -182,8 +221,8 @@ func ConvertToWLCG(record *CollectorRecord) (*WLCGRecord, error) {
 	// Add metadata
 	hostname, _ := os.Hostname()
 	wlcg.Metadata = map[string]interface{}{
-		"producer":    "cms",
-		"type":        "aaa-ng",
+		"producer":    meta.Producer,
+		"type":        meta.Type,
 		"timestamp":   time.Now().UnixNano() / int64(time.Millisecond),
 		"type_prefix": "raw",
 		"host":        hostname,
@@ -310,22 +349,30 @@ type GStreamMetadata struct {
 	ID         string `json:"_id"`
 }
 
+// Cache and TPC gstream type constants used in WLCG GStream metadata
+const (
+	gstreamCacheType = "metric"
+	gstreamTPCType   = "tpc"
+)
+
 // ConvertGStreamToWLCG adds WLCG metadata to a gstream event map
 // Based on references/wlcg_converter.py::ConvertGstream
-func ConvertGStreamToWLCG(event map[string]interface{}, isTPC bool) (map[string]interface{}, error) {
+func ConvertGStreamToWLCG(event map[string]interface{}, isTPC bool, meta WLCGMetadata) (map[string]interface{}, error) {
+	meta = meta.withDefaults()
+
 	eventCopy := make(map[string]interface{})
 	for k, v := range event {
 		eventCopy[k] = v
 	}
 
 	hostname, _ := os.Hostname()
-	eventType := "metric"
+	eventType := gstreamCacheType
 	if isTPC {
-		eventType = "tpc"
+		eventType = gstreamTPCType
 	}
 
 	eventCopy["metadata"] = GStreamMetadata{
-		Producer:   "cms-xrootd-cache",
+		Producer:   meta.GStreamProducer,
 		Type:       eventType,
 		Timestamp:  time.Now().UnixNano() / int64(time.Millisecond),
 		TypePrefix: "raw",

--- a/collector/wlcg_converter.go
+++ b/collector/wlcg_converter.go
@@ -92,7 +92,10 @@ type WLCGMetadata struct {
 }
 
 // DefaultWLCGMetadata returns the producer/type values hardcoded in the OSG
-// upstream collector, used when no override is configured.
+// upstream collector, used when no override is configured. This is the single
+// source of truth for those defaults: the config layer (config.go) deliberately
+// leaves unset fields empty and relies on withDefaults() to fill them, so the
+// defaults are defined in exactly one place.
 func DefaultWLCGMetadata() WLCGMetadata {
 	return WLCGMetadata{
 		Producer:        "cms",

--- a/collector/wlcg_converter_test.go
+++ b/collector/wlcg_converter_test.go
@@ -7,6 +7,16 @@ import (
 	"time"
 )
 
+// testWLCGMetadata returns sample WLCG metadata for converter tests.
+// This fixture just feeds the converter known values.
+func testWLCGMetadata() WLCGMetadata {
+	return WLCGMetadata{
+		Producer:        "cms",
+		Type:            "aaa-ng",
+		GStreamProducer: "cms-xrootd-cache",
+	}
+}
+
 func TestIsWLCGPacket(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -123,7 +133,7 @@ func TestConvertToWLCG(t *testing.T) {
 		HasFileCloseMsg:        1,
 	}
 
-	wlcg, err := ConvertToWLCG(record, DefaultWLCGMetadata())
+	wlcg, err := ConvertToWLCG(record, testWLCGMetadata())
 	if err != nil {
 		t.Fatalf("ConvertToWLCG() error = %v", err)
 	}
@@ -259,7 +269,7 @@ func TestConvertToWLCG_WriteOperation(t *testing.T) {
 		Write:         5000000,
 	}
 
-	wlcg, err := ConvertToWLCG(record, DefaultWLCGMetadata())
+	wlcg, err := ConvertToWLCG(record, testWLCGMetadata())
 	if err != nil {
 		t.Fatalf("ConvertToWLCG() error = %v", err)
 	}
@@ -288,7 +298,7 @@ func TestConvertToWLCG_UnknownOperation(t *testing.T) {
 		Write:         0,
 	}
 
-	wlcg, err := ConvertToWLCG(record, DefaultWLCGMetadata())
+	wlcg, err := ConvertToWLCG(record, testWLCGMetadata())
 	if err != nil {
 		t.Fatalf("ConvertToWLCG() error = %v", err)
 	}
@@ -310,8 +320,8 @@ func TestGenerateUUID(t *testing.T) {
 		VO:        "cms",
 	}
 
-	wlcg1, _ := ConvertToWLCG(record, DefaultWLCGMetadata())
-	wlcg2, _ := ConvertToWLCG(record, DefaultWLCGMetadata())
+	wlcg1, _ := ConvertToWLCG(record, testWLCGMetadata())
+	wlcg2, _ := ConvertToWLCG(record, testWLCGMetadata())
 
 	// Check basic format (8-4-4-4-12 hex characters)
 	if len(wlcg1.UniqueID) != 36 {
@@ -428,7 +438,7 @@ func TestConvertGStreamToWLCG(t *testing.T) {
 		"server_hostname":  "xrootd.cern.ch",
 	}
 
-	wlcgEvent, err := ConvertGStreamToWLCG(event, false, DefaultWLCGMetadata())
+	wlcgEvent, err := ConvertGStreamToWLCG(event, false, testWLCGMetadata())
 	if err != nil {
 		t.Fatalf("ConvertGStreamToWLCG() error = %v", err)
 	}
@@ -630,7 +640,7 @@ func TestConvertGStreamToWLCG_TPC(t *testing.T) {
 		"size":        int64(1000000),
 	}
 
-	wlcgEvent, err := ConvertGStreamToWLCG(event, true, DefaultWLCGMetadata())
+	wlcgEvent, err := ConvertGStreamToWLCG(event, true, testWLCGMetadata())
 	if err != nil {
 		t.Fatalf("ConvertGStreamToWLCG() error = %v", err)
 	}

--- a/collector/wlcg_converter_test.go
+++ b/collector/wlcg_converter_test.go
@@ -123,7 +123,7 @@ func TestConvertToWLCG(t *testing.T) {
 		HasFileCloseMsg:        1,
 	}
 
-	wlcg, err := ConvertToWLCG(record)
+	wlcg, err := ConvertToWLCG(record, DefaultWLCGMetadata())
 	if err != nil {
 		t.Fatalf("ConvertToWLCG() error = %v", err)
 	}
@@ -259,7 +259,7 @@ func TestConvertToWLCG_WriteOperation(t *testing.T) {
 		Write:         5000000,
 	}
 
-	wlcg, err := ConvertToWLCG(record)
+	wlcg, err := ConvertToWLCG(record, DefaultWLCGMetadata())
 	if err != nil {
 		t.Fatalf("ConvertToWLCG() error = %v", err)
 	}
@@ -288,7 +288,7 @@ func TestConvertToWLCG_UnknownOperation(t *testing.T) {
 		Write:         0,
 	}
 
-	wlcg, err := ConvertToWLCG(record)
+	wlcg, err := ConvertToWLCG(record, DefaultWLCGMetadata())
 	if err != nil {
 		t.Fatalf("ConvertToWLCG() error = %v", err)
 	}
@@ -310,8 +310,8 @@ func TestGenerateUUID(t *testing.T) {
 		VO:        "cms",
 	}
 
-	wlcg1, _ := ConvertToWLCG(record)
-	wlcg2, _ := ConvertToWLCG(record)
+	wlcg1, _ := ConvertToWLCG(record, DefaultWLCGMetadata())
+	wlcg2, _ := ConvertToWLCG(record, DefaultWLCGMetadata())
 
 	// Check basic format (8-4-4-4-12 hex characters)
 	if len(wlcg1.UniqueID) != 36 {
@@ -428,7 +428,7 @@ func TestConvertGStreamToWLCG(t *testing.T) {
 		"server_hostname":  "xrootd.cern.ch",
 	}
 
-	wlcgEvent, err := ConvertGStreamToWLCG(event, false)
+	wlcgEvent, err := ConvertGStreamToWLCG(event, false, DefaultWLCGMetadata())
 	if err != nil {
 		t.Fatalf("ConvertGStreamToWLCG() error = %v", err)
 	}
@@ -630,7 +630,7 @@ func TestConvertGStreamToWLCG_TPC(t *testing.T) {
 		"size":        int64(1000000),
 	}
 
-	wlcgEvent, err := ConvertGStreamToWLCG(event, true)
+	wlcgEvent, err := ConvertGStreamToWLCG(event, true, DefaultWLCGMetadata())
 	if err != nil {
 		t.Fatalf("ConvertGStreamToWLCG() error = %v", err)
 	}
@@ -642,5 +642,60 @@ func TestConvertGStreamToWLCG_TPC(t *testing.T) {
 
 	if metadata.Type != "tpc" {
 		t.Errorf("Type = %v, expected tpc", metadata.Type)
+	}
+}
+
+func TestConvertToWLCG_CustomMetadata(t *testing.T) {
+	record := &CollectorRecord{
+		Site:     "T2_US_Nebraska",
+		Filename: "/store/data/file.root",
+		VO:       "cms",
+		Read:     1000,
+	}
+
+	meta := WLCGMetadata{Producer: "osg", Type: "transfer"}
+	wlcg, err := ConvertToWLCG(record, meta)
+	if err != nil {
+		t.Fatalf("ConvertToWLCG() error = %v", err)
+	}
+
+	if wlcg.Metadata["producer"] != "osg" {
+		t.Errorf("Metadata producer = %v, expected osg", wlcg.Metadata["producer"])
+	}
+	if wlcg.Metadata["type"] != "transfer" {
+		t.Errorf("Metadata type = %v, expected transfer", wlcg.Metadata["type"])
+	}
+}
+
+func TestConvertGStreamToWLCG_CustomMetadata(t *testing.T) {
+	// Only the gstream producer is configurable; the metadata.type values are
+	// structural constants ("metric"/"tpc") and must not change with config.
+	meta := WLCGMetadata{GStreamProducer: "osg-xrootd-cache"}
+
+	cache, err := ConvertGStreamToWLCG(map[string]interface{}{"file_path": "/store/x"}, false, meta)
+	if err != nil {
+		t.Fatalf("ConvertGStreamToWLCG(cache) error = %v", err)
+	}
+	cm, ok := cache["metadata"].(GStreamMetadata)
+	if !ok {
+		t.Fatal("cache metadata should be GStreamMetadata type")
+	}
+	if cm.Producer != "osg-xrootd-cache" {
+		t.Errorf("cache Producer = %v, expected osg-xrootd-cache", cm.Producer)
+	}
+	if cm.Type != "metric" {
+		t.Errorf("cache Type = %v, expected metric (structural constant)", cm.Type)
+	}
+
+	tpc, err := ConvertGStreamToWLCG(map[string]interface{}{"source": "root://x//store/a"}, true, meta)
+	if err != nil {
+		t.Fatalf("ConvertGStreamToWLCG(tpc) error = %v", err)
+	}
+	tm, ok := tpc["metadata"].(GStreamMetadata)
+	if !ok {
+		t.Fatal("tpc metadata should be GStreamMetadata type")
+	}
+	if tm.Type != "tpc" {
+		t.Errorf("tpc Type = %v, expected tpc (structural constant)", tm.Type)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -8,9 +8,19 @@ import (
 	"github.com/spf13/viper"
 )
 
+// WLCGConfig holds both the routing rules that decide whether a record is a
+// WLCG packet and the producer/type values written into the metadata block of
+// WLCG-formatted records. These differ between deployments, so they are
+// configurable instead of hardcoded.
 type WLCGConfig struct {
+	// Routing: which records are treated as WLCG packets.
 	VOs          []string // case-insensitive exact match; defaults to ["cms"]
 	PathPrefixes []string // HasPrefix match; defaults to ["/store", "/user/dteam"]
+
+	// Metadata: producer/type values written into WLCG-formatted records.
+	Producer        string // metadata.producer for file-transfer (file-close) records
+	Type            string // metadata.type for file-transfer records
+	GStreamProducer string // metadata.producer for gstream cache & TPC records
 }
 
 type FilterConfig struct {
@@ -55,17 +65,6 @@ type OutputConfig struct {
 	Path string // File path for "file" or "both" output types
 }
 
-// WLCGConfig holds the producer/type values used to create the metadata block of
-// WLCG-formatted records. These differ between deployments, so they are
-// configurable instead of hardcoded. Unset fields stay empty here and are filled at
-// conversion time by collector.WLCGMetadata.withDefaults(), which owns the OSG
-// upstream collector's default values (a single source of truth for those defaults).
-type WLCGConfig struct {
-	Producer        string // metadata.producer for file-transfer (file-close) records
-	Type            string // metadata.type for file-transfer records
-	GStreamProducer string // metadata.producer for gstream cache & TPC records
-}
-
 type Config struct {
 	Input                 InputConfig
 	State                 StateConfig
@@ -101,7 +100,6 @@ type Config struct {
 	QueueDir              string
 	IpMapAll              string
 	IpMap                 map[string]string
-	WLCG                  WLCGConfig
 	Filter                FilterConfig
 }
 
@@ -319,13 +317,14 @@ func (c *Config) ReadConfigWithPathAndPrefix(configPath string, envPrefix string
 	c.ProfilePort = viper.GetInt("profile.port")
 
 	// WLCG metadata configuration (producer/type used to create WLCG-formatted records).
-	// Only explicitly configured values are read here; any field left unset stays empty
-	// and is filled at conversion time by collector.WLCGMetadata.withDefaults(), which is
-	// the single source of truth for the OSG upstream collector's default values. Keeping
-	// the defaults in one place avoids the config layer and the converter silently diverging.
-	// Override these for a WLCG (or other) deployment via config file or environment variables.
+	// These viper defaults are the single source of truth for the values and match the OSG
+	// upstream collector; a config file or COLLECTOR_WLCG_* environment variable
+	// overrides them for a WLCG (or other) deployment.
+	viper.SetDefault("wlcg.producer", "cms")
 	c.WLCG.Producer = viper.GetString("wlcg.producer")
+	viper.SetDefault("wlcg.type", "aaa-ng")
 	c.WLCG.Type = viper.GetString("wlcg.type")
+	viper.SetDefault("wlcg.gstream_producer", "cms-xrootd-cache")
 	c.WLCG.GStreamProducer = viper.GetString("wlcg.gstream_producer")
 
 	viper.SetDefault("queue_directory", "/var/spool/xrootd-monitoring-shoveler/queue")

--- a/config.go
+++ b/config.go
@@ -55,10 +55,21 @@ type OutputConfig struct {
 	Path string // File path for "file" or "both" output types
 }
 
+// WLCGConfig holds the producer/type values used to create the metadata block of
+// WLCG-formatted records. These differ between deployments, so they are
+// configurable instead of hardcoded. Empty values fall back to the default
+// values used by the OSG upstream collector.
+type WLCGConfig struct {
+	Producer        string // metadata.producer for file-transfer (file-close) records
+	Type            string // metadata.type for file-transfer records
+	GStreamProducer string // metadata.producer for gstream cache & TPC records
+}
+
 type Config struct {
 	Input                 InputConfig
 	State                 StateConfig
 	Output                OutputConfig
+	WLCG                  WLCGConfig
 	Mode                  string   // Operating mode: "shoveler" or "collector"
 	MQ                    string   // Which technology to use for the MQ connection
 	AmqpURL               *url.URL // AMQP URL (password comes from the token)
@@ -305,6 +316,16 @@ func (c *Config) ReadConfigWithPathAndPrefix(configPath string, envPrefix string
 	c.Profile = viper.GetBool("profile.enable")
 	viper.SetDefault("profile.port", 3030)
 	c.ProfilePort = viper.GetInt("profile.port")
+
+	// WLCG metadata configuration (producer/type used to create WLCG-formatted records).
+	// Defaults match the OSG upstream collector's values; override them for a
+	// WLCG (or other) deployment via config file or environment variables.
+	viper.SetDefault("wlcg.producer", "cms")
+	c.WLCG.Producer = viper.GetString("wlcg.producer")
+	viper.SetDefault("wlcg.type", "aaa-ng")
+	c.WLCG.Type = viper.GetString("wlcg.type")
+	viper.SetDefault("wlcg.gstream_producer", "cms-xrootd-cache")
+	c.WLCG.GStreamProducer = viper.GetString("wlcg.gstream_producer")
 
 	viper.SetDefault("queue_directory", "/var/spool/xrootd-monitoring-shoveler/queue")
 	c.QueueDir = viper.GetString("queue_directory")

--- a/config.go
+++ b/config.go
@@ -57,8 +57,9 @@ type OutputConfig struct {
 
 // WLCGConfig holds the producer/type values used to create the metadata block of
 // WLCG-formatted records. These differ between deployments, so they are
-// configurable instead of hardcoded. Empty values fall back to the default
-// values used by the OSG upstream collector.
+// configurable instead of hardcoded. Unset fields stay empty here and are filled at
+// conversion time by collector.WLCGMetadata.withDefaults(), which owns the OSG
+// upstream collector's default values (a single source of truth for those defaults).
 type WLCGConfig struct {
 	Producer        string // metadata.producer for file-transfer (file-close) records
 	Type            string // metadata.type for file-transfer records
@@ -318,13 +319,13 @@ func (c *Config) ReadConfigWithPathAndPrefix(configPath string, envPrefix string
 	c.ProfilePort = viper.GetInt("profile.port")
 
 	// WLCG metadata configuration (producer/type used to create WLCG-formatted records).
-	// Defaults match the OSG upstream collector's values; override them for a
-	// WLCG (or other) deployment via config file or environment variables.
-	viper.SetDefault("wlcg.producer", "cms")
+	// Only explicitly configured values are read here; any field left unset stays empty
+	// and is filled at conversion time by collector.WLCGMetadata.withDefaults(), which is
+	// the single source of truth for the OSG upstream collector's default values. Keeping
+	// the defaults in one place avoids the config layer and the converter silently diverging.
+	// Override these for a WLCG (or other) deployment via config file or environment variables.
 	c.WLCG.Producer = viper.GetString("wlcg.producer")
-	viper.SetDefault("wlcg.type", "aaa-ng")
 	c.WLCG.Type = viper.GetString("wlcg.type")
-	viper.SetDefault("wlcg.gstream_producer", "cms-xrootd-cache")
 	c.WLCG.GStreamProducer = viper.GetString("wlcg.gstream_producer")
 
 	viper.SetDefault("queue_directory", "/var/spool/xrootd-monitoring-shoveler/queue")

--- a/config/config-collector.yaml
+++ b/config/config-collector.yaml
@@ -74,6 +74,18 @@ amqp:
 #  cert: path/to/cert/file
 #  certkey: path/to/certkey/file
 
+# WLCG metadata holds the configurable producer/type values that are used
+# in the "metadata" block of WLCG-formatted records.
+# These identify the data source and differ between deployments; override them
+# here instead of editing the code. Values below are the defaults, matching the
+# OSG upstream collector (opensciencegrid/xrootd-monitoring-collector).
+# Equivalent environment variables: COLLECTOR_WLCG_PRODUCER, COLLECTOR_WLCG_TYPE,
+# COLLECTOR_WLCG_GSTREAM_PRODUCER.
+#wlcg:
+#  producer: cms                      # producer for file-transfer (file-close) records
+#  type: aaa-ng                       # type for file-transfer records
+#  gstream_producer: cms-xrootd-cache # producer for gstream cache & TPC records
+
 listen:
   port: 9993
   ip: 0.0.0.0


### PR DESCRIPTION
Closes #98 

Makes the `producer`/`type` values in the WLCG record `metadata` block configurable instead of hardcoded, via new `wlcg:` config.

Defaults match the current OSG upstream collector, so existing deployments are unaffected.